### PR TITLE
Return only allow statements in effective policy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@cloud-copilot/cli": "^0.1.30",
         "@cloud-copilot/iam-collect": "^0.1.75",
         "@cloud-copilot/iam-data": "^0.9.202505242",
+        "@cloud-copilot/iam-expand": "^0.11.13",
         "@cloud-copilot/iam-policy": "^0.1.27",
         "@cloud-copilot/iam-simulate": "^0.1.42",
         "@cloud-copilot/iam-utils": "^0.1.7"
@@ -2506,6 +2507,21 @@
       "resolved": "https://registry.npmjs.org/@cloud-copilot/iam-data/-/iam-data-0.9.202505311.tgz",
       "integrity": "sha512-DL3q1sIDWj5RNyneKSKl3YvvHkw0fbMH/9NSR6E53MyWQna2P0G9vmYeuIEA4Pbcpw72t2/ik6g2HWnhGrujvA==",
       "license": "MIT"
+    },
+    "node_modules/@cloud-copilot/iam-expand": {
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/@cloud-copilot/iam-expand/-/iam-expand-0.11.13.tgz",
+      "integrity": "sha512-1wuKZxfqqlZmNYqYNNY2Nl7p6vAFxS+IaW6pDscdYdGC4MWjwTes+z/UZqHpuLFmXvXjSmldr2lByGIRrdyQ0A==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@cloud-copilot/cli": "^0.1.16"
+      },
+      "bin": {
+        "iam-expand": "dist/esm/cli.js"
+      },
+      "peerDependencies": {
+        "@cloud-copilot/iam-data": ">=0.7.0 <1.0.0"
+      }
     },
     "node_modules/@cloud-copilot/iam-policy": {
       "version": "0.1.27",

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "@cloud-copilot/cli": "^0.1.30",
     "@cloud-copilot/iam-collect": "^0.1.75",
     "@cloud-copilot/iam-data": "^0.9.202505242",
+    "@cloud-copilot/iam-expand": "^0.11.13",
     "@cloud-copilot/iam-policy": "^0.1.27",
     "@cloud-copilot/iam-simulate": "^0.1.42",
     "@cloud-copilot/iam-utils": "^0.1.7"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,9 +2,9 @@
 
 import { parseCliArguments } from '@cloud-copilot/cli'
 import { getCollectClient, loadCollectConfigs } from './collect/collect.js'
+import { calculateEffectivePolicy } from './effectivePolicy.js'
 import { ContextKeys } from './simulate/contextKeys.js'
 import { resultMatchesExpectation, simulateRequest } from './simulate/simulate.js'
-import { calculateEffectivePolicy } from "./effectivePolicy.js"
 import { iamLensVersion } from './utils/packageVersion.js'
 import { whoCan } from './whoCan/whoCan.js'
 
@@ -81,17 +81,17 @@ const main = async () => {
               'The action to check permissions for; must be a valid IAM service and action such as `s3:GetObject`'
           }
         }
-      }
-      "effective-policy": {
-        description: "Compute the effective policy for a principal",
+      },
+      'effective-policy': {
+        description: 'Compute the effective policy for a principal',
         options: {
           principal: {
-            type: "string",
-            values: "single",
-            description: "The principal ARN to calculate the effective policy for"
+            type: 'string',
+            values: 'single',
+            description: 'The principal ARN to calculate the effective policy for'
           }
         }
-      },
+      }
     },
     {
       collectConfigs: {
@@ -165,11 +165,10 @@ const main = async () => {
     })
 
     console.log(JSON.stringify(results, null, 2))
-  } else if (cli.subcommand === "effective-policy") {
+  } else if (cli.subcommand === 'effective-policy') {
     const principal = cli.args.principal as string
     const result = await calculateEffectivePolicy(collectClient, principal)
     console.log(JSON.stringify(result, null, 2))
-
   }
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { parseCliArguments } from '@cloud-copilot/cli'
 import { getCollectClient, loadCollectConfigs } from './collect/collect.js'
 import { ContextKeys } from './simulate/contextKeys.js'
 import { resultMatchesExpectation, simulateRequest } from './simulate/simulate.js'
+import { calculateEffectivePolicy } from "./effectivePolicy.js"
 import { iamLensVersion } from './utils/packageVersion.js'
 import { whoCan } from './whoCan/whoCan.js'
 
@@ -81,6 +82,16 @@ const main = async () => {
           }
         }
       }
+      "effective-policy": {
+        description: "Compute the effective policy for a principal",
+        options: {
+          principal: {
+            type: "string",
+            values: "single",
+            description: "The principal ARN to calculate the effective policy for"
+          }
+        }
+      },
     },
     {
       collectConfigs: {
@@ -154,6 +165,11 @@ const main = async () => {
     })
 
     console.log(JSON.stringify(results, null, 2))
+  } else if (cli.subcommand === "effective-policy") {
+    const principal = cli.args.principal as string
+    const result = await calculateEffectivePolicy(collectClient, principal)
+    console.log(JSON.stringify(result, null, 2))
+
   }
 }
 

--- a/src/effectivePolicy.test.ts
+++ b/src/effectivePolicy.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import {
+  actionPatternMatches,
+  arnPatternMatches,
+  calculateEffectivePolicy,
+  SingleActionStatement,
+  EffectivePolicyDocument
+} from './effectivePolicy.js'
+import * as principals from './principals.js'
+
+describe('pattern matching helpers', () => {
+  it('matches action when wildcard pattern covers it', () => {
+    expect(actionPatternMatches('s3:*', 's3:GetObject')).toBe(true)
+  })
+
+  it('does not match when candidate is broader than pattern', () => {
+    expect(actionPatternMatches('s3:GetObject', 's3:*')).toBe(false)
+  })
+
+  it('matches arn patterns correctly', () => {
+    expect(arnPatternMatches('arn:aws:s3:::bucket/*', 'arn:aws:s3:::bucket/path/*')).toBe(true)
+    expect(arnPatternMatches('arn:aws:s3:::bucket/path/*', 'arn:aws:s3:::bucket/*')).toBe(false)
+  })
+})
+
+describe('condition merging from boundaries', () => {
+  const principal = 'arn:aws:iam::123456789012:user/Bob'
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('applies permission boundary conditions to allows', async () => {
+    const principalPolicies = {
+      managedPolicies: [],
+      inlinePolicies: [
+        {
+          name: 'inline',
+          policy: {
+            Version: '2012-10-17',
+            Statement: [
+              { Effect: 'Allow', Action: 's3:GetObject', Resource: '*' }
+            ]
+          }
+        }
+      ],
+      permissionBoundary: {
+        name: 'pb',
+        policy: {
+          Version: '2012-10-17',
+          Statement: [
+            {
+              Effect: 'Allow',
+              Action: 's3:GetObject',
+              Resource: '*',
+              Condition: { Bool: { 'aws:MultiFactorAuthPresent': 'true' } }
+            }
+          ]
+        }
+      },
+      scps: [],
+      rcps: [],
+      groupPolicies: []
+    }
+
+    vi.spyOn(principals, 'getAllPoliciesForPrincipal').mockResolvedValue(principalPolicies as any)
+
+    const result = await calculateEffectivePolicy({} as any, principal)
+    const allow = result.Statement.find(
+      (s: SingleActionStatement) => s.Effect === 'Allow'
+    ) as SingleActionStatement
+    expect(allow.Condition).toEqual({ Bool: { 'aws:MultiFactorAuthPresent': 'true' } })
+  })
+})
+
+describe('calculateEffectivePolicy scp gating', () => {
+  const principal = 'arn:aws:iam::123456789012:user/Bob'
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('keeps allows permitted by every scp level', async () => {
+    const principalPolicies = {
+      managedPolicies: [],
+      inlinePolicies: [
+        {
+          name: 'inline',
+          policy: {
+            Version: '2012-10-17',
+            Statement: [
+              { Effect: 'Allow', Action: 's3:GetObject', Resource: 'arn:aws:s3:::my-bucket/*' }
+            ]
+          }
+        }
+      ],
+      permissionBoundary: undefined,
+      scps: [
+        {
+          orgIdentifier: 'root',
+          policies: [
+            {
+              name: 'root-allow',
+              policy: { Version: '2012-10-17', Statement: [{ Effect: 'Allow', Action: 's3:*', Resource: '*' }] }
+            }
+          ]
+        },
+        {
+          orgIdentifier: 'ou',
+          policies: [
+            {
+              name: 'ou-allow',
+              policy: { Version: '2012-10-17', Statement: [{ Effect: 'Allow', Action: 's3:GetObject', Resource: 'arn:aws:s3:::my-bucket/*' }] }
+            }
+          ]
+        }
+      ],
+      rcps: [],
+      groupPolicies: []
+    }
+
+    vi.spyOn(principals, 'getAllPoliciesForPrincipal').mockResolvedValue(principalPolicies as any)
+
+    const result = await calculateEffectivePolicy({} as any, principal)
+    expect(result.Statement.length).toBe(1)
+    expect((result.Statement[0] as SingleActionStatement).Action).toBe('s3:GetObject')
+  })
+
+  it('drops allows not covered by all scp levels', async () => {
+    const principalPolicies = {
+      managedPolicies: [],
+      inlinePolicies: [
+        {
+          name: 'inline',
+          policy: {
+            Version: '2012-10-17',
+            Statement: [
+              { Effect: 'Allow', Action: 's3:GetObject', Resource: 'arn:aws:s3:::my-bucket/*' }
+            ]
+          }
+        }
+      ],
+      permissionBoundary: undefined,
+      scps: [
+        {
+          orgIdentifier: 'root',
+          policies: [
+            {
+              name: 'root-allow',
+              policy: { Version: '2012-10-17', Statement: [{ Effect: 'Allow', Action: 's3:*', Resource: '*' }] }
+            }
+          ]
+        },
+        {
+          orgIdentifier: 'ou',
+          policies: [
+            {
+              name: 'ou-deny-only',
+              policy: { Version: '2012-10-17', Statement: [{ Effect: 'Deny', Action: 's3:*', Resource: '*' }] }
+            }
+          ]
+        }
+      ],
+      rcps: [],
+      groupPolicies: []
+    }
+
+    vi.spyOn(principals, 'getAllPoliciesForPrincipal').mockResolvedValue(principalPolicies as any)
+
+    const result = await calculateEffectivePolicy({} as any, principal)
+    const allows = result.Statement.filter(
+      (s: SingleActionStatement) => s.Effect === 'Allow'
+    )
+    expect(allows.length).toBe(0)
+  })
+})

--- a/src/effectivePolicy.ts
+++ b/src/effectivePolicy.ts
@@ -1,0 +1,378 @@
+import { loadPolicy, Statement } from '@cloud-copilot/iam-policy'
+import { expandJsonDocument } from '@cloud-copilot/iam-expand'
+import { IamCollectClient } from './collect/client.js'
+import { getAllPoliciesForPrincipal } from './principals.js'
+
+export interface SingleActionStatement {
+  Effect: 'Allow' | 'Deny'
+  Action: string
+  Resource?: string
+  NotResource?: string | string[]
+  Condition?: any
+}
+
+export interface EffectivePolicyDocument {
+  Version: '2012-10-17'
+  Statement: SingleActionStatement[]
+}
+
+/**
+ * Convert a list of iam-policy Condition objects to the raw JSON shape.
+ */
+function conditionsToObject(conds: any[]): any | undefined {
+  if (!conds || conds.length === 0) {
+    return undefined
+  }
+  const result: Record<string, any> = {}
+  for (const cond of conds) {
+    const op = (cond as any).op
+    const key = (cond as any).key
+    const values = (cond as any).values
+    if (!result[op]) {
+      result[op] = {}
+    }
+    result[op][key] = values
+  }
+  return result
+}
+
+async function extractStatements(policyDoc: any): Promise<SingleActionStatement[]> {
+  const expanded = JSON.parse(JSON.stringify(policyDoc))
+  await expandJsonDocument({ invertNotActions: true }, expanded)
+  const policy = loadPolicy(expanded)
+  const results: SingleActionStatement[] = []
+  for (const stmt of policy.statements()) {
+    const actions = (stmt as Statement).isActionStatement()
+      ? (stmt as any).actions().map((a: any) => a.value())
+      : ['*']
+    const resources = (stmt as Statement).isResourceStatement()
+      ? (stmt as any).resources().map((r: any) => r.value())
+      : ['*']
+    const notResources = (stmt as Statement).isNotResourceStatement()
+      ? (stmt as any).notResources().map((r: any) => r.value())
+      : []
+    const condition = conditionsToObject((stmt as any).conditions())
+    for (const action of actions) {
+      if (resources.length === 0 && notResources.length === 0) {
+        const statement: SingleActionStatement = {
+          Effect: stmt.effect() as 'Allow' | 'Deny',
+          Action: action,
+          Resource: '*'
+        }
+        if (condition) {
+          statement.Condition = condition
+        }
+        results.push(statement)
+        continue
+      }
+      for (const resource of resources.length > 0 ? resources : ['*']) {
+        const statement: SingleActionStatement = {
+          Effect: stmt.effect() as 'Allow' | 'Deny',
+          Action: action,
+          Resource: resource
+        }
+        if (condition) {
+          statement.Condition = condition
+        }
+        results.push(statement)
+      }
+      if (notResources.length > 0) {
+        const statement: SingleActionStatement = {
+          Effect: stmt.effect() as 'Allow' | 'Deny',
+          Action: action,
+          Resource: '*',
+          NotResource: notResources.length === 1 ? notResources[0] : notResources
+        }
+        if (condition) {
+          statement.Condition = condition
+        }
+        results.push(statement)
+      }
+    }
+  }
+  return results
+}
+
+function arnPatternsOverlap(a: string, b: string): boolean {
+  if (a === '*' || b === '*') {
+    return true
+  }
+  if (a === b) {
+    return true
+  }
+  if (a.endsWith('*') && b.startsWith(a.slice(0, -1))) {
+    return true
+  }
+  if (b.endsWith('*') && a.startsWith(b.slice(0, -1))) {
+    return true
+  }
+  return false
+}
+
+function globMatch(pattern: string, value: string): boolean {
+  if (pattern === '*') {
+    return true
+  }
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*')
+  const re = new RegExp(`^${escaped}$`)
+  return re.test(value)
+}
+
+export function arnPatternMatches(pattern: string, candidate: string): boolean {
+  return globMatch(pattern, candidate)
+}
+
+export function actionPatternMatches(pattern: string, action: string): boolean {
+  return globMatch(pattern, action)
+}
+
+function resourceMatches(pattern: string, resource: string): boolean {
+  return arnPatternMatches(pattern, resource)
+}
+
+function statementAppliesToResource(stmt: SingleActionStatement, resource: string): boolean {
+  if (stmt.Resource) {
+    return resourceMatches(stmt.Resource, resource)
+  }
+  if (stmt.NotResource) {
+    const patterns = Array.isArray(stmt.NotResource) ? stmt.NotResource : [stmt.NotResource]
+    return !patterns.some((p) => resourceMatches(p, resource))
+  }
+  return true
+}
+
+function invertConditionOperator(op: string): string | undefined {
+  const map: Record<string, string> = {
+    StringNotEquals: 'StringEquals',
+    StringEquals: 'StringNotEquals',
+    StringLike: 'StringNotLike',
+    StringNotLike: 'StringLike',
+    NumericEquals: 'NumericNotEquals',
+    NumericNotEquals: 'NumericEquals',
+    NumericLessThan: 'NumericGreaterThanEquals',
+    NumericLessThanEquals: 'NumericGreaterThan',
+    NumericGreaterThan: 'NumericLessThanEquals',
+    NumericGreaterThanEquals: 'NumericLessThan',
+    DateEquals: 'DateNotEquals',
+    DateNotEquals: 'DateEquals',
+    DateLessThan: 'DateGreaterThanEquals',
+    DateLessThanEquals: 'DateGreaterThan',
+    DateGreaterThan: 'DateLessThanEquals',
+    DateGreaterThanEquals: 'DateLessThan',
+    Bool: 'Bool',
+    Null: 'Null'
+  }
+  return map[op]
+}
+
+function invertConditionBlock(cond: any): any | null {
+  const result: Record<string, any> = {}
+  for (const [op, val] of Object.entries(cond)) {
+    const invertedOp = invertConditionOperator(op)
+    if (!invertedOp) {
+      return null
+    }
+    if (!result[invertedOp]) {
+      result[invertedOp] = {}
+    }
+    for (const [key, value] of Object.entries(val as any)) {
+      result[invertedOp][key] = value
+    }
+  }
+  return result
+}
+
+function mergeConditionObjects(a: any, b: any): any {
+  if (!a) {
+    return JSON.parse(JSON.stringify(b))
+  }
+  for (const [op, val] of Object.entries(b)) {
+    if (!a[op]) {
+      a[op] = {}
+    }
+    for (const [key, value] of Object.entries(val as any)) {
+      const existing = a[op][key]
+      const values = Array.isArray(value) ? value : [value]
+      if (!existing) {
+        a[op][key] = values.length === 1 ? values[0] : values
+      } else {
+        const existingArr = Array.isArray(existing) ? existing : [existing]
+        const merged = Array.from(new Set([...existingArr, ...values]))
+        a[op][key] = merged.length === 1 ? merged[0] : merged
+      }
+    }
+  }
+  return a
+}
+
+function combineAllowConditions(stmts: SingleActionStatement[]): any | undefined {
+  let result: any | undefined
+  for (const s of stmts) {
+    if (!s.Condition) {
+      return undefined
+    }
+    result = mergeConditionObjects(result, s.Condition)
+  }
+  return result
+}
+
+/**
+ * Calculate the effective policy for a principal by gathering all identity and
+ * organizational policies. Resource policies are not currently included.
+ */
+export async function calculateEffectivePolicy(
+  collectClient: IamCollectClient,
+  principalArn: string
+): Promise<EffectivePolicyDocument> {
+  const principalPolicies = await getAllPoliciesForPrincipal(collectClient, principalArn)
+
+  const identityPolicies: any[] = []
+  identityPolicies.push(...principalPolicies.managedPolicies.map((p) => p.policy))
+  identityPolicies.push(...principalPolicies.inlinePolicies.map((p) => p.policy))
+  for (const group of principalPolicies.groupPolicies || []) {
+    identityPolicies.push(...group.managedPolicies.map((p) => p.policy))
+    identityPolicies.push(...group.inlinePolicies.map((p) => p.policy))
+  }
+
+  const identityStatements = (
+    await Promise.all(identityPolicies.map((p) => extractStatements(p)))
+  ).flat()
+  const identityAllows = identityStatements.filter((s) => s.Effect === 'Allow')
+  const identityDenies = identityStatements.filter((s) => s.Effect === 'Deny')
+
+  let boundaryAllows: SingleActionStatement[] = []
+  let boundaryDenies: SingleActionStatement[] = []
+  if (principalPolicies.permissionBoundary) {
+    const boundaryStmts = await extractStatements(principalPolicies.permissionBoundary.policy)
+    boundaryAllows = boundaryStmts.filter((s) => s.Effect === 'Allow')
+    boundaryDenies = boundaryStmts.filter((s) => s.Effect === 'Deny')
+  }
+
+  const scpLevels = await Promise.all(
+    principalPolicies.scps.map(async (scpLevel) => {
+      const stmts = (
+        await Promise.all(scpLevel.policies.map((p) => extractStatements(p.policy)))
+      ).flat()
+      return {
+        allows: stmts.filter((s) => s.Effect === 'Allow'),
+        denies: stmts.filter((s) => s.Effect === 'Deny')
+      }
+    })
+  )
+  const scpDenies = scpLevels.flatMap((l) => l.denies)
+
+  const rcpStatements = (
+    await Promise.all(
+      principalPolicies.rcps.flatMap((rcp) =>
+        rcp.policies.map((p) => extractStatements(p.policy))
+      )
+    )
+  ).flat()
+  const rcpAllows = rcpStatements.filter((s) => s.Effect === 'Allow')
+  const rcpDenies = rcpStatements.filter((s) => s.Effect === 'Deny')
+
+  const allDenies = [...identityDenies, ...scpDenies, ...boundaryDenies, ...rcpDenies]
+
+  const scopedIdentityAllows: SingleActionStatement[] = []
+  for (const allow of identityAllows) {
+    let combinedCond: any = allow.Condition ? JSON.parse(JSON.stringify(allow.Condition)) : undefined
+    let allowed = true
+
+    for (const level of scpLevels) {
+      const matches = level.allows.filter(
+        (scp) =>
+          actionPatternMatches(scp.Action, allow.Action) &&
+          statementAppliesToResource(scp, allow.Resource!)
+      )
+      if (matches.length === 0) {
+        allowed = false
+        break
+      }
+      const levelCond = combineAllowConditions(matches)
+      if (levelCond) {
+        combinedCond = mergeConditionObjects(combinedCond, levelCond)
+      }
+    }
+
+    if (!allowed) {
+      continue
+    }
+
+    if (boundaryAllows.length > 0) {
+      const matches = boundaryAllows.filter(
+        (pb) =>
+          actionPatternMatches(pb.Action, allow.Action) &&
+          statementAppliesToResource(pb, allow.Resource!)
+      )
+      if (matches.length === 0) {
+        continue
+      }
+      const cond = combineAllowConditions(matches)
+      if (cond) {
+        combinedCond = mergeConditionObjects(combinedCond, cond)
+      }
+    }
+
+    if (rcpAllows.length > 0) {
+      const matches = rcpAllows.filter(
+        (rcp) =>
+          actionPatternMatches(rcp.Action, allow.Action) &&
+          statementAppliesToResource(rcp, allow.Resource!)
+      )
+      if (matches.length === 0) {
+        continue
+      }
+      const cond = combineAllowConditions(matches)
+      if (cond) {
+        combinedCond = mergeConditionObjects(combinedCond, cond)
+      }
+    }
+
+    scopedIdentityAllows.push({ ...allow, Condition: combinedCond })
+  }
+
+  const finalAllows: SingleActionStatement[] = []
+  for (const allow of scopedIdentityAllows) {
+    const overlappingDenies = allDenies.filter((deny) => {
+      if (!actionPatternMatches(deny.Action, allow.Action)) {
+        return false
+      }
+      if (deny.Resource) {
+        return arnPatternsOverlap(deny.Resource, allow.Resource!)
+      }
+      if (deny.NotResource) {
+        const patterns = Array.isArray(deny.NotResource) ? deny.NotResource : [deny.NotResource]
+        return !patterns.some((p) => arnPatternMatches(p, allow.Resource!))
+      }
+      return true
+    })
+    if (overlappingDenies.length === 0) {
+      finalAllows.push(allow)
+      continue
+    }
+
+    let combined: any = allow.Condition
+    let dropAllow = false
+    for (const deny of overlappingDenies) {
+      if (!deny.Condition) {
+        dropAllow = true
+        break
+      }
+      const inverted = invertConditionBlock(deny.Condition)
+      if (!inverted) {
+        dropAllow = true
+        break
+      }
+      combined = mergeConditionObjects(combined, inverted)
+    }
+    if (!dropAllow) {
+      finalAllows.push({ ...allow, Condition: combined })
+    }
+  }
+
+  return {
+    Version: '2012-10-17',
+    Statement: finalAllows
+  }
+}
+


### PR DESCRIPTION
## Summary
- show only allow statements in effective policy output

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683f442bc2e48325b7372c19791bb4ca