### PR TITLE
fix: Add null checks and improve error handling for group ARNs

### DIFF
--- a/docs/PrincipalCan.md
+++ b/docs/PrincipalCan.md
@@ -16,10 +16,10 @@ You can use this:
 
 ## Options
 
-| Flag                          | Description                                                             |
-| ----------------------------- | ----------------------------------------------------------------------- |
-| `--principal <arn>`           | The principal to check permissions for. Can be a user or role ARN.      |
-| `-s`, `--shrink-action-lists` | Shrink action lists to reduce policy size using wildcard consolidation. |
+| Flag                          | Description                                                                  |
+| ----------------------------- | ---------------------------------------------------------------------------- |
+| `--principal <arn>`           | The principal to check permissions for. Can be a user, role, or group ARN.   |
+| `-s`, `--shrink-action-lists` | Shrink action lists to reduce policy size using wildcard consolidation.      |
 
 You can also use any of the [Global CLI Options](GlobalCliOptions.md).
 
@@ -59,6 +59,10 @@ iam-lens principal-can \
 iam-lens principal-can \
   --principal arn:aws:iam::123456789012:role/MyRole \
   --shrink-action-lists
+
+# Get permissions for a group
+iam-lens principal-can \
+  --principal arn:aws:iam::123456789012:group/Developers
 
 # Analyze permissions across accounts (if cross-account policies exist)
 iam-lens principal-can \

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -103,7 +103,8 @@ const main = async () => {
           'Create a consolidated view of all permissions for a principal, see readme for limitations',
         arguments: {
           principal: stringArgument({
-            description: 'The principal to check permissions for. Can be a user, role, or group'
+            description:
+              'The principal to check permissions for. Can be a user, role, or group. Note: Groups are evaluated for identity-based policies only; they cannot be used as principals in resource-based policies'
           }),
           shrinkActionLists: booleanArgument({
             description: 'Shrink action lists to reduce policy size',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -103,7 +103,7 @@ const main = async () => {
           'Create a consolidated view of all permissions for a principal, see readme for limitations',
         arguments: {
           principal: stringArgument({
-            description: 'The principal to check permissions for. Can be a user or role'
+            description: 'The principal to check permissions for. Can be a user, role, or group'
           }),
           shrinkActionLists: booleanArgument({
             description: 'Shrink action lists to reduce policy size',

--- a/src/principals.test.ts
+++ b/src/principals.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isServiceLinkedRole } from './principals.js'
+import { isServiceLinkedRole, isIamGroupArn } from './principals.js'
 
 describe('isServiceLinkedRole', () => {
   it('should return true for service-linked role ARNs', () => {
@@ -31,6 +31,63 @@ describe('isServiceLinkedRole', () => {
 
     //When checking if it is a service-linked role
     const result = isServiceLinkedRole(nonArnPrincipal)
+
+    //Then it should return false
+    expect(result).toBe(false)
+  })
+})
+
+describe('isIamGroupArn', () => {
+  it('should return true for IAM group ARNs', () => {
+    //Given an IAM group ARN
+    const groupArn = 'arn:aws:iam::123456789012:group/Developers'
+
+    //When checking if it is a group ARN
+    const result = isIamGroupArn(groupArn)
+
+    //Then it should return true
+    expect(result).toBe(true)
+  })
+
+  it('should return true for IAM group ARNs with paths', () => {
+    //Given an IAM group ARN with a path
+    const groupArn = 'arn:aws:iam::123456789012:group/engineering/Developers'
+
+    //When checking if it is a group ARN
+    const result = isIamGroupArn(groupArn)
+
+    //Then it should return true
+    expect(result).toBe(true)
+  })
+
+  it('should return false for IAM user ARNs', () => {
+    //Given an IAM user ARN
+    const userArn = 'arn:aws:iam::123456789012:user/alice'
+
+    //When checking if it is a group ARN
+    const result = isIamGroupArn(userArn)
+
+    //Then it should return false
+    expect(result).toBe(false)
+  })
+
+  it('should return false for IAM role ARNs', () => {
+    //Given an IAM role ARN
+    const roleArn = 'arn:aws:iam::123456789012:role/MyRole'
+
+    //When checking if it is a group ARN
+    const result = isIamGroupArn(roleArn)
+
+    //Then it should return false
+    expect(result).toBe(false)
+  })
+
+  it('should return false for non-ARN principals', () => {
+    //Given a non-ARN principal
+    const nonArnPrincipal = 'some-principal.amazonaws.com'
+
+    //When checking if it is a group ARN
+    const result = isIamGroupArn(nonArnPrincipal)
 
     //Then it should return false
     expect(result).toBe(false)

--- a/src/principals.test.ts
+++ b/src/principals.test.ts
@@ -92,4 +92,15 @@ describe('isIamGroupArn', () => {
     //Then it should return false
     expect(result).toBe(false)
   })
+
+  it('should return false for malformed ARNs', () => {
+    //Given a malformed ARN
+    const malformedArn = 'arn:aws:iam::'
+
+    //When checking if it is a group ARN
+    const result = isIamGroupArn(malformedArn)
+
+    //Then it should return false
+    expect(result).toBe(false)
+  })
 })

--- a/src/principals.ts
+++ b/src/principals.ts
@@ -23,7 +23,7 @@ export function isIamGroupArn(principal: string): boolean {
     return false
   }
   const parts = splitArnParts(principal)
-  return parts.service === 'iam' && parts.resourceType === 'group'
+  return parts?.service === 'iam' && parts?.resourceType === 'group'
 }
 
 export interface PrincipalPolicies {
@@ -117,7 +117,10 @@ export async function getAllPoliciesForGroup(
   collectClient: IamCollectClient,
   principalArn: string
 ): Promise<PrincipalPolicies> {
-  const accountId = splitArnParts(principalArn).accountId!
+  const accountId = splitArnParts(principalArn).accountId
+  if (!accountId) {
+    throw new Error(`Invalid group ARN: missing account ID in ${principalArn}`)
+  }
 
   const managedPolicies = await collectClient.getManagedPoliciesForGroup(principalArn)
   const inlinePolicies = await collectClient.getInlinePoliciesForGroup(principalArn)

--- a/src/principals.ts
+++ b/src/principals.ts
@@ -12,6 +12,20 @@ import {
   type SimulationOrgPolicies
 } from './collect/client.js'
 
+/**
+ * Test if a principal string is an IAM Group ARN
+ *
+ * @param principal the principal string to test
+ * @returns true if the principal is an IAM group ARN, false otherwise
+ */
+export function isIamGroupArn(principal: string): boolean {
+  if (!principal.startsWith('arn:')) {
+    return false
+  }
+  const parts = splitArnParts(principal)
+  return parts.service === 'iam' && parts.resourceType === 'group'
+}
+
 export interface PrincipalPolicies {
   managedPolicies: ManagedPolicy[]
   inlinePolicies: InlinePolicy[]
@@ -92,6 +106,33 @@ export async function getAllPoliciesForRole(
   }
 }
 
+/**
+ * Get all the IAM policies for a group, including managed and inline policies.
+ *
+ * @param collectClient the IAM collect client to use for retrieving policies
+ * @param principalArn the ARN of the group to get policies for
+ * @returns an object containing the managed policies, inline policies, and SCPs/RCPs
+ */
+export async function getAllPoliciesForGroup(
+  collectClient: IamCollectClient,
+  principalArn: string
+): Promise<PrincipalPolicies> {
+  const accountId = splitArnParts(principalArn).accountId!
+
+  const managedPolicies = await collectClient.getManagedPoliciesForGroup(principalArn)
+  const inlinePolicies = await collectClient.getInlinePoliciesForGroup(principalArn)
+  const scps = await collectClient.getScpHierarchyForAccount(accountId)
+  const rcps = await collectClient.getRcpHierarchyForAccount(accountId)
+
+  return {
+    scps,
+    rcps,
+    managedPolicies,
+    inlinePolicies,
+    permissionBoundary: undefined
+  }
+}
+
 export async function getAllPoliciesForPrincipal(
   collectClient: IamCollectClient,
   principalArn: string
@@ -118,6 +159,8 @@ export async function getAllPoliciesForPrincipal(
   } else if (isAssumedRoleArn(principalArn)) {
     const roleArn = convertAssumedRoleArnToRoleArn(principalArn)
     return getAllPoliciesForRole(collectClient, roleArn)
+  } else if (isIamGroupArn(principalArn)) {
+    return getAllPoliciesForGroup(collectClient, principalArn)
   }
   throw new Error(`Unsupported principal type: ${principalArn}`)
 }


### PR DESCRIPTION
## Summary

Address code review feedback:
- Add explicit null check for accountId instead of non-null assertion
- Use optional chaining in isIamGroupArn for malformed ARNs
- Add test case for malformed ARN input
- Clarify in CLI that groups are identity-based only

This prevents cryptic errors when malformed ARNs are passed and makes
it clearer that groups cannot be used as principals in resource-based
policies (AWS limitation).

## Test plan
- Tests pass
- Manual verification completed