### PR TITLE
fix: verify whoCan question mark resource patterns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@cloud-copilot/iam-expand": "^0.11.29",
         "@cloud-copilot/iam-policy": "^0.1.89",
         "@cloud-copilot/iam-shrink": "^0.1.21",
-        "@cloud-copilot/iam-simulate": "^0.1.141",
+        "@cloud-copilot/iam-simulate": "^0.1.142",
         "@cloud-copilot/iam-utils": "^0.1.63",
         "@cloud-copilot/job": "^0.1.0",
         "@cloud-copilot/log": "^0.1.39",
@@ -2863,9 +2863,9 @@
       }
     },
     "node_modules/@cloud-copilot/iam-simulate": {
-      "version": "0.1.141",
-      "resolved": "https://registry.npmjs.org/@cloud-copilot/iam-simulate/-/iam-simulate-0.1.141.tgz",
-      "integrity": "sha512-eflfsgJ7tNixZBffiBMaVFTDgpBl2diRUbBZ/+i1+WyDun6KROhYLwNdbeaQisyxi4EETOzWTrK054Ub171/yA==",
+      "version": "0.1.142",
+      "resolved": "https://registry.npmjs.org/@cloud-copilot/iam-simulate/-/iam-simulate-0.1.142.tgz",
+      "integrity": "sha512-FLHmXALYO5wWH8YPeobVBj6Y7WwCN3WVl0Etqytv25aLIXYZYNJlNO2ksPy1Vzc9hW4AOTaA7g9afsKMPjf3WQ==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@cloud-copilot/iam-data": ">=0.15.202511222 <1.0.0",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "@cloud-copilot/iam-expand": "^0.11.29",
     "@cloud-copilot/iam-policy": "^0.1.89",
     "@cloud-copilot/iam-shrink": "^0.1.21",
-    "@cloud-copilot/iam-simulate": "^0.1.141",
+    "@cloud-copilot/iam-simulate": "^0.1.142",
     "@cloud-copilot/iam-utils": "^0.1.63",
     "@cloud-copilot/job": "^0.1.0",
     "@cloud-copilot/log": "^0.1.39",

--- a/src/test-datasets/iam-data-1/aws/aws/accounts/100000000001/iam/role/s3objectwildcardrole/inline-policies.json
+++ b/src/test-datasets/iam-data-1/aws/aws/accounts/100000000001/iam/role/s3objectwildcardrole/inline-policies.json
@@ -16,6 +16,11 @@
           "Effect": "Deny",
           "Action": ["s3:GetObject"],
           "Resource": ["arn:aws:s3:::wildcard-bucket/reports/private/*"]
+        },
+        {
+          "Effect": "Allow",
+          "Action": ["s3:DeleteObject"],
+          "Resource": "arn:aws:s3:::??-example-data-lake/db_tables/v5/*/_delta_log/*"
         }
       ]
     }

--- a/src/test-datasets/iam-data-1/aws/aws/accounts/100000000001/s3/eu-example-data-lake/metadata.json
+++ b/src/test-datasets/iam-data-1/aws/aws/accounts/100000000001/s3/eu-example-data-lake/metadata.json
@@ -1,0 +1,5 @@
+{
+  "name": "eu-example-data-lake",
+  "region": "us-west-2",
+  "arn": "arn:aws:s3:::eu-example-data-lake"
+}

--- a/src/test-datasets/iam-data-1/aws/aws/indexes/buckets-to-accounts.json
+++ b/src/test-datasets/iam-data-1/aws/aws/indexes/buckets-to-accounts.json
@@ -55,6 +55,10 @@
     "accountId": "200000000002",
     "region": "us-west-2"
   },
+  "eu-example-data-lake": {
+    "accountId": "100000000001",
+    "region": "us-west-2"
+  },
   "wildcard-bucket": {
     "accountId": "100000000001",
     "region": "us-west-2"

--- a/src/whoCan/whoCanIntegration.test.ts
+++ b/src/whoCan/whoCanIntegration.test.ts
@@ -378,6 +378,44 @@ const whoCanIntegrationTests: WhoCanIntegrationTest[] = [
     }
   },
   {
+    name: 'S3 object wildcard with policy question marks and request wildcard',
+    simulationCounts: { withoutIndex: 3, withIndex: 2 },
+    data: '1',
+    request: {
+      resource: 'arn:aws:s3:::eu-example-data-lake/db_tables/v5/table/_delta_log/*',
+      actions: ['s3:DeleteObject']
+    },
+    expected: {
+      who: [
+        {
+          action: 'DeleteObject',
+          principal: 'arn:aws:iam::100000000001:role/S3ObjectWildcardRole',
+          service: 's3',
+          level: 'write',
+          allowedPatterns: [
+            {
+              pattern: 'arn:aws:s3:::??-example-data-lake/db_tables/v5/*/_delta_log/*',
+              resourceType: 'object'
+            }
+          ]
+        },
+        {
+          action: 'DeleteObject',
+          principal:
+            'arn:aws:iam::100000000001:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_AdministratorAccess_0fed56ec5d997fc5',
+          service: 's3',
+          level: 'write',
+          allowedPatterns: [
+            {
+              pattern: '*',
+              resourceType: 'object'
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
     name: 'S3 object wildcard (different prefix)',
     simulationCounts: { withoutIndex: 3, withIndex: 3 },
     data: '1',


### PR DESCRIPTION
## Summary
- bump iam-simulate to 0.1.142
- add whoCan integration coverage for policy resource question-mark wildcards

## Tests
- npm run build
- npm test
- npm run format-check