### PR TITLE
chore: update iam-simulate dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@cloud-copilot/iam-expand": "^0.11.29",
         "@cloud-copilot/iam-policy": "^0.1.89",
         "@cloud-copilot/iam-shrink": "^0.1.21",
-        "@cloud-copilot/iam-simulate": "^0.1.142",
+        "@cloud-copilot/iam-simulate": "^0.1.147",
         "@cloud-copilot/iam-utils": "^0.1.63",
         "@cloud-copilot/job": "^0.1.0",
         "@cloud-copilot/log": "^0.1.39",
@@ -1528,9 +1528,9 @@
       }
     },
     "node_modules/@cloud-copilot/iam-simulate": {
-      "version": "0.1.146",
-      "resolved": "https://registry.npmjs.org/@cloud-copilot/iam-simulate/-/iam-simulate-0.1.146.tgz",
-      "integrity": "sha512-8VHr4/+bic3NNgswp73y1zBA5C+kSlxZSU5e6YzOxeInIMjURKaQZ6MNpgauTbDuNAxgPv8QRXrSZ13h3s1vBw==",
+      "version": "0.1.147",
+      "resolved": "https://registry.npmjs.org/@cloud-copilot/iam-simulate/-/iam-simulate-0.1.147.tgz",
+      "integrity": "sha512-k+FBg4LRCGsFiOlKnNX/bFfUzY0wpXZGHHx9kePTTKomwy9C+BPS/jAIT36afm/QXE75cfbsNmG1kN8KzdRG8Q==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@cloud-copilot/iam-data": ">=0.15.202511222 <1.0.0",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "@cloud-copilot/iam-expand": "^0.11.29",
     "@cloud-copilot/iam-policy": "^0.1.89",
     "@cloud-copilot/iam-shrink": "^0.1.21",
-    "@cloud-copilot/iam-simulate": "^0.1.142",
+    "@cloud-copilot/iam-simulate": "^0.1.147",
     "@cloud-copilot/iam-utils": "^0.1.63",
     "@cloud-copilot/job": "^0.1.0",
     "@cloud-copilot/log": "^0.1.39",


### PR DESCRIPTION
## Summary
- update @cloud-copilot/iam-simulate minimum dependency to ^0.1.147
- refresh package-lock.json to install iam-simulate 0.1.147