### PR TITLE
fix: handle wildcard-account principal arn scope

### DIFF
--- a/src/test-datasets/iam-data-2/aws/aws/accounts/400000000002/s3/mixed-principalarn-bucket/metadata.json
+++ b/src/test-datasets/iam-data-2/aws/aws/accounts/400000000002/s3/mixed-principalarn-bucket/metadata.json
@@ -1,0 +1,5 @@
+{
+  "name": "mixed-principalarn-bucket",
+  "region": "us-east-1",
+  "arn": "arn:aws:s3:::mixed-principalarn-bucket"
+}

--- a/src/test-datasets/iam-data-2/aws/aws/accounts/400000000002/s3/mixed-principalarn-bucket/policy.json
+++ b/src/test-datasets/iam-data-2/aws/aws/accounts/400000000002/s3/mixed-principalarn-bucket/policy.json
@@ -1,0 +1,35 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowWildcardAccountAndFixedAccountPrincipalArnPatterns",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::mixed-principalarn-bucket/*",
+      "Condition": {
+        "StringLike": {
+          "aws:PrincipalArn": [
+            "arn:aws:iam::*:role/alpha-*",
+            "arn:aws:iam::400000000002:role/s3-reader"
+          ]
+        }
+      }
+    },
+    {
+      "Sid": "DenyNonMatchingPrincipalArnPatterns",
+      "Effect": "Deny",
+      "Principal": "*",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::mixed-principalarn-bucket/*",
+      "Condition": {
+        "StringNotLike": {
+          "aws:PrincipalArn": [
+            "arn:aws:iam::*:role/alpha-*",
+            "arn:aws:iam::400000000002:role/s3-reader"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/src/whoCan/whoCan.test.ts
+++ b/src/whoCan/whoCan.test.ts
@@ -1201,6 +1201,105 @@ const accountsToCheckBasedOnResourcePolicyTests: {
       resourceAccountTrustedByPolicy: true
     }
   },
+  {
+    name: 'PrincipalArn: StringLike mixed wildcard-account and fixed-account role paths',
+    resourcePolicy: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Sid: 'ExplicitlyAllowWildCardRolePaths',
+          Effect: 'Allow',
+          Action: ['secretsmanager:DescribeSecret', 'secretsmanager:GetSecretValue'],
+          Principal: { AWS: '*' },
+          Resource: '*',
+          Condition: {
+            StringLike: {
+              'aws:PrincipalArn': [
+                'arn:aws:iam::*:role/ecs-tasks/*',
+                'arn:aws:iam::*:role/k8s-pod/cicd/*',
+                'arn:aws:iam::*:role/lambda/util/*',
+                'arn:aws:iam::123456789012:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_engineer_*',
+                'arn:aws:iam::123456789012:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_super_*',
+                'arn:aws:iam::123456789012:role/bx_admin',
+                'arn:aws:iam::123456789012:role/bx_super',
+                'arn:aws:iam::123456789012:role/engineer',
+                'arn:aws:iam::123456789012:role/security_controls/*',
+                'arn:aws:iam::123456789012:role/xa-tfe/dply/tfe-deployment'
+              ]
+            }
+          }
+        },
+        {
+          Sid: 'ExplicitlyDenyOtherWildCardRolePaths',
+          Effect: 'Deny',
+          Action: 'secretsmanager:GetSecretValue',
+          Principal: { AWS: '*' },
+          Resource: '*',
+          Condition: {
+            StringNotLike: {
+              'aws:PrincipalArn': [
+                'arn:aws:iam::*:role/ecs-tasks/*',
+                'arn:aws:iam::*:role/k8s-pod/cicd/*',
+                'arn:aws:iam::*:role/lambda/util/*',
+                'arn:aws:iam::123456789012:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_engineer_*',
+                'arn:aws:iam::123456789012:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_super_*',
+                'arn:aws:iam::123456789012:role/bx_admin',
+                'arn:aws:iam::123456789012:role/bx_super',
+                'arn:aws:iam::123456789012:role/engineer',
+                'arn:aws:iam::123456789012:role/security_controls/*',
+                'arn:aws:iam::123456789012:role/xa-tfe/dply/tfe-deployment'
+              ]
+            }
+          }
+        }
+      ]
+    },
+    resourceAccountId: '123456789012',
+    expected: {
+      allAccounts: true,
+      // Each fixed-account wildcard role path contributes an account entry; literal ARNs contribute specific principals, and later account resolution deduplicates account entries.
+      specificAccounts: ['123456789012', '123456789012', '123456789012'],
+      specificPrincipals: [
+        'arn:aws:iam::123456789012:role/bx_admin',
+        'arn:aws:iam::123456789012:role/bx_super',
+        'arn:aws:iam::123456789012:role/engineer',
+        'arn:aws:iam::123456789012:role/xa-tfe/dply/tfe-deployment'
+      ],
+      checkAnonymous: false,
+      checkAllFromResourceAccount: true,
+      resourceAccountTrustedByPolicy: true
+    }
+  },
+  {
+    name: 'PrincipalArn: wildcard account still narrows when PrincipalAccount is present',
+    resourcePolicy: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Effect: 'Allow',
+          Principal: '*',
+          Action: '*',
+          Resource: '*',
+          Condition: {
+            StringLike: {
+              'aws:PrincipalArn': 'arn:aws:iam::*:role/ApplicationRole'
+            },
+            StringEquals: {
+              'aws:PrincipalAccount': '123456789012'
+            }
+          }
+        }
+      ]
+    },
+    resourceAccountId: '000000000000',
+    expected: {
+      allAccounts: false,
+      specificAccounts: ['123456789012'],
+      checkAnonymous: false,
+      checkAllFromResourceAccount: false,
+      resourceAccountTrustedByPolicy: false
+    }
+  },
   // --- aws:PrincipalArn: Dynamic variables ---
   {
     name: 'PrincipalArn: dynamic variable with no account',

--- a/src/whoCan/whoCan.ts
+++ b/src/whoCan/whoCan.ts
@@ -630,6 +630,8 @@ export async function accountsToCheckBasedOnResourcePolicy(
         const specificOus: string[] = []
         const specificAccounts: string[] = []
         const specificPrincipals: string[] = []
+        let principalArnRequiresAllAccounts = false
+        let hasNonPrincipalArnAccountNarrowing = false
 
         const conditions = statement.conditions()
         for (const cond of conditions) {
@@ -657,6 +659,7 @@ export async function accountsToCheckBasedOnResourcePolicy(
             if (opVal.startsWith('stringequals') && !hasDynamic) {
               // StringEquals family — all values are literal account IDs
               specificAccounts.push(...values)
+              hasNonPrincipalArnAccountNarrowing = true
             } else if (
               baseOp === 'stringlike' &&
               !hasDynamic &&
@@ -664,6 +667,7 @@ export async function accountsToCheckBasedOnResourcePolicy(
             ) {
               // StringLike where ALL values are literal (no wildcards or dynamic vars)
               specificAccounts.push(...values)
+              hasNonPrincipalArnAccountNarrowing = true
             }
           }
 
@@ -682,9 +686,11 @@ export async function accountsToCheckBasedOnResourcePolicy(
             }
 
             for (const value of cond.conditionValues()) {
+              let extractedPrincipalArnScope = false
               if (!hasWildcardOrDynamic(value)) {
                 // Exact literal — push as a specific principal
                 specificPrincipals.push(value)
+                extractedPrincipalArnScope = true
               } else if (isExactOperator && !value.includes('*') && !value.includes('?')) {
                 // Exact operator with a dynamic variable but no wildcards — try account extraction
                 const segments = splitArnIgnoringDynamicVars(value)
@@ -692,6 +698,7 @@ export async function accountsToCheckBasedOnResourcePolicy(
                   const account = segments[4]
                   if (account && !hasWildcardOrDynamic(account)) {
                     specificAccounts.push(account)
+                    extractedPrincipalArnScope = true
                   }
                 }
               } else {
@@ -701,8 +708,14 @@ export async function accountsToCheckBasedOnResourcePolicy(
                   const account = segments[4]
                   if (account && !hasWildcardOrDynamic(account)) {
                     specificAccounts.push(account)
+                    extractedPrincipalArnScope = true
                   }
                 }
+              }
+
+              if (!extractedPrincipalArnScope) {
+                // Wildcard-account or otherwise non-extractable PrincipalArn patterns can match any account.
+                principalArnRequiresAllAccounts = true
               }
             }
           }
@@ -711,7 +724,19 @@ export async function accountsToCheckBasedOnResourcePolicy(
         if (specificPrincipals.length > 0) {
           accountsToCheck.specificPrincipals.push(...specificPrincipals)
         }
-        if (specificAccounts.length > 0) {
+        if (
+          principalArnRequiresAllAccounts &&
+          specificOus.length === 0 &&
+          specificOrgs.length === 0 &&
+          !hasNonPrincipalArnAccountNarrowing
+        ) {
+          accountsToCheck.allAccounts = true
+          accountsToCheck.resourceAccountTrustedByPolicy = true
+          accountsToCheck.checkAllFromResourceAccount = true
+          if (specificAccounts.length > 0) {
+            accountsToCheck.specificAccounts.push(...specificAccounts)
+          }
+        } else if (specificAccounts.length > 0) {
           accountsToCheck.specificAccounts.push(...specificAccounts)
           if (resourceAccount && specificAccounts.includes(resourceAccount)) {
             accountsToCheck.resourceAccountTrustedByPolicy = true

--- a/src/whoCan/whoCanIntegration.test.ts
+++ b/src/whoCan/whoCanIntegration.test.ts
@@ -1318,6 +1318,36 @@ const whoCanIntegrationTests: WhoCanIntegrationTest[] = [
     }
   },
   {
+    name: 'mixed wildcard-account and fixed-account PrincipalArn resource policy',
+    description:
+      'Bucket policy with Principal:"*" and StringLike aws:PrincipalArn includes both wildcard-account and fixed-account patterns. Expected: alpha-role from account 400000000001 is checked and allowed even though only account 400000000002 is explicitly named in a condition value.',
+    data: '2',
+    request: {
+      resource: 'arn:aws:s3:::mixed-principalarn-bucket/object.txt',
+      resourceAccount: '400000000002',
+      actions: ['s3:GetObject']
+    },
+    expected: {
+      who: [
+        {
+          action: 'GetObject',
+          principal: 'arn:aws:iam::400000000001:role/alpha-role',
+          service: 's3',
+          level: 'read',
+          resourceType: 'object'
+        },
+        {
+          action: 'GetObject',
+          principal: 'arn:aws:iam::400000000002:role/s3-reader',
+          service: 's3',
+          level: 'read',
+          resourceType: 'object'
+        }
+      ],
+      allAccountsChecked: true
+    }
+  },
+  {
     name: 'mixed explicit account grant plus wildcard PrincipalArn',
     simulationCounts: { withoutIndex: 26, withIndex: 26 },
     description:


### PR DESCRIPTION
## Summary

- Fix `accountsToCheckBasedOnResourcePolicy` so positive `aws:PrincipalArn` patterns with wildcard account segments set `allAccounts: true` when not independently narrowed by PrincipalAccount/CallerAccount/org/OU conditions.
- Preserve extracted fixed-account/specific-principal hints while still broadening candidate account selection for wildcard-account patterns.
- Add unit coverage for mixed wildcard-account and fixed-account PrincipalArn conditions plus a PrincipalAccount narrowing guard.
- Add integration coverage proving a principal from an account not explicitly named in the condition is checked and allowed via the wildcard-account PrincipalArn pattern.
