### PR TITLE
fix: map principal arn sessions to roles

### DIFF
--- a/src/test-datasets/iam-data-1/aws/aws/accounts/200000000002/s3/who-can-session-principalarn/metadata.json
+++ b/src/test-datasets/iam-data-1/aws/aws/accounts/200000000002/s3/who-can-session-principalarn/metadata.json
@@ -1,0 +1,5 @@
+{
+  "name": "who-can-session-principalarn",
+  "region": "us-east-1",
+  "arn": "arn:aws:s3:::who-can-session-principalarn"
+}

--- a/src/test-datasets/iam-data-1/aws/aws/accounts/200000000002/s3/who-can-session-principalarn/policy.json
+++ b/src/test-datasets/iam-data-1/aws/aws/accounts/200000000002/s3/who-can-session-principalarn/policy.json
@@ -1,0 +1,19 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "SharingWithSessionArnAndPrincipalArnCondition",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": ["arn:aws:sts::200000000002:assumed-role/DynamoDbRole/my-session"]
+      },
+      "Action": ["s3:ListBucket"],
+      "Resource": ["arn:aws:s3:::who-can-session-principalarn"],
+      "Condition": {
+        "StringEquals": {
+          "aws:PrincipalArn": "arn:aws:iam::200000000002:role/DynamoDbRole"
+        }
+      }
+    }
+  ]
+}

--- a/src/whoCan/whoCan.test.ts
+++ b/src/whoCan/whoCan.test.ts
@@ -2493,7 +2493,7 @@ const accountsToCheckBasedOnResourcePolicyTests: {
     }
   },
   {
-    name: 'should NOT convert assumed-role session ARN in PrincipalArn condition',
+    name: 'should convert assumed-role session ARN to role ARN in PrincipalArn condition',
     resourcePolicy: {
       Version: '2012-10-17',
       Statement: [
@@ -2512,7 +2512,62 @@ const accountsToCheckBasedOnResourcePolicyTests: {
     },
     resourceAccountId: '000000000000',
     expected: {
-      specificPrincipals: ['arn:aws:sts::777777777777:assumed-role/SpecificRole/session-123'],
+      specificPrincipals: ['arn:aws:iam::777777777777:role/SpecificRole'],
+      specificAccounts: [],
+      checkAnonymous: false,
+      checkAllFromResourceAccount: false,
+      resourceAccountTrustedByPolicy: false
+    }
+  },
+  {
+    name: 'should convert assumed-role session ARN with path to role ARN in PrincipalArn condition',
+    resourcePolicy: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Effect: 'Allow',
+          Principal: '*',
+          Action: '*',
+          Resource: '*',
+          Condition: {
+            StringEquals: {
+              'aws:PrincipalArn':
+                'arn:aws:sts::777777777777:assumed-role/path/to/SpecificRole/session-123'
+            }
+          }
+        }
+      ]
+    },
+    resourceAccountId: '000000000000',
+    expected: {
+      specificPrincipals: ['arn:aws:iam::777777777777:role/path/to/SpecificRole'],
+      specificAccounts: [],
+      checkAnonymous: false,
+      checkAllFromResourceAccount: false,
+      resourceAccountTrustedByPolicy: false
+    }
+  },
+  {
+    name: 'should convert exact assumed-role session ARN under ArnLike PrincipalArn condition',
+    resourcePolicy: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Effect: 'Allow',
+          Principal: '*',
+          Action: '*',
+          Resource: '*',
+          Condition: {
+            ArnLike: {
+              'aws:PrincipalArn': 'arn:aws:sts::777777777777:assumed-role/SpecificRole/session-123'
+            }
+          }
+        }
+      ]
+    },
+    resourceAccountId: '000000000000',
+    expected: {
+      specificPrincipals: ['arn:aws:iam::777777777777:role/SpecificRole'],
       specificAccounts: [],
       checkAnonymous: false,
       checkAllFromResourceAccount: false,

--- a/src/whoCan/whoCan.ts
+++ b/src/whoCan/whoCan.ts
@@ -689,7 +689,7 @@ export async function accountsToCheckBasedOnResourcePolicy(
               let extractedPrincipalArnScope = false
               if (!hasWildcardOrDynamic(value)) {
                 // Exact literal — push as a specific principal
-                specificPrincipals.push(value)
+                specificPrincipals.push(convertSessionArnToRoleArn(value))
                 extractedPrincipalArnScope = true
               } else if (isExactOperator && !value.includes('*') && !value.includes('?')) {
                 // Exact operator with a dynamic variable but no wildcards — try account extraction

--- a/src/whoCan/whoCanIntegration.test.ts
+++ b/src/whoCan/whoCanIntegration.test.ts
@@ -250,6 +250,43 @@ const whoCanIntegrationTests: WhoCanIntegrationTest[] = [
     }
   },
   {
+    name: 'session ARN principal with PrincipalArn condition returns role ARN',
+    description:
+      'Resource policy grants a session ARN principal and constrains aws:PrincipalArn to the attached role ARN. The whoCan result should be the IAM role ARN, not the STS session ARN.',
+    data: '1',
+    request: {
+      resource: 'arn:aws:s3:::who-can-session-principalarn',
+      resourceAccount: '200000000002',
+      actions: ['s3:ListBucket']
+    },
+    expected: {
+      who: [
+        {
+          action: 'ListBucket',
+          level: 'list',
+          principal: 'arn:aws:iam::200000000002:role/DynamoDbRole',
+          service: 's3',
+          resourceType: 'bucket',
+          dependsOnSessionName: true
+        },
+        {
+          action: 'ListBucket',
+          level: 'list',
+          principal: 'arn:aws:iam::200000000002:role/S3CrossAccountRole',
+          service: 's3',
+          resourceType: 'bucket'
+        },
+        {
+          action: 'ListBucket',
+          principal: 'arn:aws:iam::200000000002:user/user1',
+          service: 's3',
+          level: 'list',
+          resourceType: 'bucket'
+        }
+      ]
+    }
+  },
+  {
     name: 'session ARN principal with aws:userid condition surfaces both flags',
     simulationCounts: { withoutIndex: 6, withIndex: 5 },
     description:


### PR DESCRIPTION
## Summary

- Convert exact literal `aws:PrincipalArn` condition values from STS assumed-role session ARNs to their attached IAM role ARNs when building whoCan specific principal candidates.
- Add unit coverage for StringEquals, path-bearing assumed-role session ARNs, and exact ArnLike PrincipalArn condition values.
- Add whoCanIntegration coverage proving a resource policy with a session ARN principal and PrincipalArn role condition returns the IAM role ARN, not the STS session ARN.
