### PR TITLE
fix: update iam-simulate discovery constraints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@cloud-copilot/iam-expand": "^0.11.29",
         "@cloud-copilot/iam-policy": "^0.1.89",
         "@cloud-copilot/iam-shrink": "^0.1.21",
-        "@cloud-copilot/iam-simulate": "^0.1.147",
+        "@cloud-copilot/iam-simulate": "^0.1.149",
         "@cloud-copilot/iam-utils": "^0.1.63",
         "@cloud-copilot/job": "^0.1.0",
         "@cloud-copilot/log": "^0.1.39",
@@ -1528,9 +1528,9 @@
       }
     },
     "node_modules/@cloud-copilot/iam-simulate": {
-      "version": "0.1.148",
-      "resolved": "https://registry.npmjs.org/@cloud-copilot/iam-simulate/-/iam-simulate-0.1.148.tgz",
-      "integrity": "sha512-hmdvwHPvcsMSPquzHvlfz3Rs7c8Y6PcwFcQvzdcZ7T3RgRS+mnDBlDHQ6j7QlsJVSW8E6rRXvWte83OZWFi2+A==",
+      "version": "0.1.149",
+      "resolved": "https://registry.npmjs.org/@cloud-copilot/iam-simulate/-/iam-simulate-0.1.149.tgz",
+      "integrity": "sha512-Am18RTi6jvSyEYV91rI1r2TnAB6bWVG0TfmnIxkPNMPRctOYLThdquGBLddDdVguXCW+PwrFf7Vh5l0hlYaoSw==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@cloud-copilot/iam-data": ">=0.15.202511222 <1.0.0",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "@cloud-copilot/iam-expand": "^0.11.29",
     "@cloud-copilot/iam-policy": "^0.1.89",
     "@cloud-copilot/iam-shrink": "^0.1.21",
-    "@cloud-copilot/iam-simulate": "^0.1.147",
+    "@cloud-copilot/iam-simulate": "^0.1.149",
     "@cloud-copilot/iam-utils": "^0.1.63",
     "@cloud-copilot/job": "^0.1.0",
     "@cloud-copilot/log": "^0.1.39",

--- a/src/simulate/simulate.ts
+++ b/src/simulate/simulate.ts
@@ -1,6 +1,7 @@
 import { iamActionDetails, iamActionExists, iamServiceExists } from '@cloud-copilot/iam-data'
 import { type ValidatedPolicy } from '@cloud-copilot/iam-policy'
 import {
+  type DiscoveryContextKeyConstraint,
   type EvaluationResult,
   type RunSimulationResults,
   runSimulation,
@@ -278,12 +279,47 @@ export async function simulateRequest(
     }
   }
 
+  const discoveryContextKeyConstraints = strictContextKeys.map(discoveryConstraintForStrictKey)
+
   const result = await runSimulation(simulation, {
     simulationMode: simulationRequest.simulationMode,
-    strictConditionKeys: strictContextKeys
+    discoveryContextKeyConstraints
   })
 
   return { request, result }
+}
+
+const awsSourceKeyPrefix = 'aws:source'
+
+/**
+ * Converts an iam-lens strict context key into an iam-simulate Discovery constraint.
+ *
+ * Most strict keys should preserve the old behavior where both presence and
+ * value are authoritative. Service source context keys are different during
+ * who-can discovery: iam-lens supplies resource-derived placeholder values, but
+ * the actual source account/org for a service principal request may differ.
+ * Treating those values as unknown lets who-can return conditional access
+ * instead of incorrectly denying service-principal statements.
+ *
+ * @param keyName the literal context key or slash-delimited key pattern
+ * @returns the Discovery constraint to pass to iam-simulate
+ */
+function discoveryConstraintForStrictKey(keyName: string): DiscoveryContextKeyConstraint {
+  if (
+    keyName.slice(0, 10).localeCompare(awsSourceKeyPrefix, undefined, { sensitivity: 'base' }) === 0
+  ) {
+    return {
+      keyName,
+      presenceIsKnown: true,
+      valueIsKnown: false
+    }
+  }
+
+  return {
+    keyName,
+    presenceIsKnown: true,
+    valueIsKnown: true
+  }
 }
 
 async function getResourcePolicies(

--- a/src/test-datasets/iam-data-2/aws/aws/accounts/400000000002/s3/service-sourceaccount-bucket/metadata.json
+++ b/src/test-datasets/iam-data-2/aws/aws/accounts/400000000002/s3/service-sourceaccount-bucket/metadata.json
@@ -1,0 +1,5 @@
+{
+  "name": "service-sourceaccount-bucket",
+  "region": "us-west-2",
+  "arn": "arn:aws:s3:::service-sourceaccount-bucket"
+}

--- a/src/test-datasets/iam-data-2/aws/aws/accounts/400000000002/s3/service-sourceaccount-bucket/policy.json
+++ b/src/test-datasets/iam-data-2/aws/aws/accounts/400000000002/s3/service-sourceaccount-bucket/policy.json
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowLambdaFromDifferentSourceAccount",
+      "Effect": "Allow",
+      "Principal": { "Service": "lambda.amazonaws.com" },
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::service-sourceaccount-bucket/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:SourceAccount": "400000000001"
+        }
+      }
+    }
+  ]
+}

--- a/src/whoCan/whoCanIntegration.test.ts
+++ b/src/whoCan/whoCanIntegration.test.ts
@@ -666,6 +666,39 @@ const whoCanIntegrationTests: WhoCanIntegrationTest[] = [
     }
   },
   {
+    name: 'service principal with different SourceAccount is conditional access',
+    description:
+      'Bucket policy names lambda.amazonaws.com and requires aws:SourceAccount from a different account than the bucket. whoCan should keep the service principal and report the SourceAccount condition instead of denying based on the resource-account placeholder value.',
+    data: '2',
+    request: {
+      resource: 'arn:aws:s3:::service-sourceaccount-bucket/example.txt',
+      resourceAccount: '400000000002',
+      actions: ['s3:PutObject']
+    },
+    expected: {
+      who: [
+        {
+          action: 'PutObject',
+          principal: 'lambda.amazonaws.com',
+          service: 's3',
+          level: 'write',
+          resourceType: 'object',
+          conditions: {
+            resource: {
+              allow: [
+                {
+                  key: 'aws:SourceAccount',
+                  op: 'StringEquals',
+                  values: ['400000000001']
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
     name: 'ListBucket with condition',
     simulationCounts: { withoutIndex: 6, withIndex: 4 },
     data: '1',


### PR DESCRIPTION
## Summary
- update @cloud-copilot/iam-simulate to ^0.1.149
- translate iam-lens strict context key collection to iam-simulate discoveryContextKeyConstraints
- preserve iam-lens public strictContextKeys/additionalStrictContextKeys naming for compatibility
- treat service source context key values as unknown during Discovery so whoCan can report conditional service-principal access
- add whoCanIntegration coverage for a service principal whose aws:SourceAccount condition differs from the resource account

## Tests
- npm run build
- npm test
- npm run format-check
