### PR TITLE
fix: resolve pathless assumed role sessions

### DIFF
--- a/src/collect/client.test.ts
+++ b/src/collect/client.test.ts
@@ -94,6 +94,53 @@ describe('IamCollectClient', () => {
       // Then it should return false
       expect(exists).toBe(false)
     })
+
+    it('should find an IAM role when stored metadata uses different ARN capitalization', async () => {
+      // Given an IAM role whose collected metadata ARN preserves canonical capitalization
+      // but whose storage key uses different capitalization
+      const { store, client } = testStore()
+      const accountId = '123456789012'
+      const collectedArn = `arn:aws:iam::${accountId}:role/awsreservedsso_engineer_abcdef1234567890`
+      const canonicalArn = `arn:aws:iam::${accountId}:role/AWSReservedSSO_engineer_abcdef1234567890`
+      await store.saveResourceMetadata(accountId, collectedArn, 'metadata', {
+        arn: canonicalArn,
+        accountId,
+        resourceType: 'role'
+      })
+
+      // When checking for the canonical principal ARN
+      const exists = await client.principalExists(canonicalArn)
+
+      // Then the principal should be treated as present
+      expect(exists).toBe(true)
+    })
+
+    it('should find a path-qualified IAM role by role name when an assumed-role ARN omits the path', async () => {
+      // Given an AWS SSO-style role stored with its IAM path and canonical capitalization
+      const { store, client } = testStore()
+      const accountId = '123456789012'
+      const collectedArn = `arn:aws:iam::${accountId}:role/aws-reserved/sso.amazonaws.com/awsreservedsso_engineer_abcdef1234567890`
+      const canonicalArn = `arn:aws:iam::${accountId}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_engineer_abcdef1234567890`
+      await store.saveResourceMetadata(accountId, collectedArn, 'metadata', {
+        arn: canonicalArn,
+        accountId,
+        resourceType: 'role'
+      })
+
+      // When checking for the role ARN derived from an STS assumed-role session principal:
+      // arn:aws:sts::123456789012:assumed-role/AWSReservedSSO_engineer_abcdef1234567890/session
+      // becomes arn:aws:iam::123456789012:role/AWSReservedSSO_engineer_abcdef1234567890
+      const convertedRoleArn = `arn:aws:iam::${accountId}:role/AWSReservedSSO_engineer_abcdef1234567890`
+      const assumedRoleArn = `arn:aws:sts::${accountId}:assumed-role/AWSReservedSSO_engineer_abcdef1234567890/session`
+      const resolvedArn = await client.resolvePrincipalArn(convertedRoleArn)
+      const resolvedAssumedRoleArn = await client.resolvePrincipalArn(assumedRoleArn)
+      const exists = await client.principalExists(convertedRoleArn)
+
+      // Then the matching role should be resolved to the stored path-qualified ARN
+      expect(resolvedArn).toBe(canonicalArn)
+      expect(resolvedAssumedRoleArn).toBe(canonicalArn)
+      expect(exists).toBe(true)
+    })
   })
 
   describe('getScpHierarchyForAccount', () => {

--- a/src/collect/client.ts
+++ b/src/collect/client.ts
@@ -13,7 +13,11 @@ import {
   validateEndpointPolicy,
   validateTrustPolicy
 } from '@cloud-copilot/iam-policy'
-import { splitArnParts } from '@cloud-copilot/iam-utils'
+import {
+  convertAssumedRoleArnToRoleArn,
+  isAssumedRoleArn,
+  splitArnParts
+} from '@cloud-copilot/iam-utils'
 import BitSet from 'bitset'
 import { gunzipSync, gzipSync } from 'zlib'
 import { decodeBitSet, decompressPrincipalString } from '../utils/bitset.js'
@@ -248,6 +252,56 @@ export class IamCollectClient {
   }
 
   /**
+   * Resolves a principal ARN to the canonical ARN stored in the collect data.
+   *
+   * STS assumed-role ARNs are first converted to their IAM role ARN form. Exact metadata
+   * matches are returned first. If an IAM role ARN is not found exactly, the role is
+   * resolved by role name within the same account. This supports STS assumed-role
+   * session ARNs because those session ARNs do not include the IAM role path.
+   *
+   * @param principalArn The ARN of the principal to resolve.
+   * @returns The canonical stored principal ARN, or undefined if no matching principal exists.
+   */
+  async resolvePrincipalArn(principalArn: string): Promise<string | undefined> {
+    const cacheKey = `resolvePrincipalArn:${principalArn}`
+    return this.withCache(cacheKey, async () => {
+      const lookupPrincipalArn = isAssumedRoleArn(principalArn)
+        ? convertAssumedRoleArnToRoleArn(principalArn)
+        : principalArn
+      const arnParts = splitArnParts(lookupPrincipalArn)
+      const accountId = arnParts.accountId!
+      const principalData = await this.storageClient.getResourceMetadata<
+        ResourceMetadata,
+        ResourceMetadata
+      >(accountId, lookupPrincipalArn, 'metadata')
+      if (principalData) {
+        return principalData.arn ?? lookupPrincipalArn
+      }
+
+      if (arnParts.service !== 'iam' || arnParts.resourceType !== 'role') {
+        return undefined
+      }
+
+      const roleName = arnParts.resourcePath?.split('/').at(-1)?.toLowerCase()
+      if (!roleName) {
+        return undefined
+      }
+
+      const accountPrincipals = await this.getAllPrincipalsInAccount(accountId)
+      const matchingRole = accountPrincipals.find((candidateArn) => {
+        const candidateParts = splitArnParts(candidateArn)
+        return (
+          candidateParts.service === 'iam' &&
+          candidateParts.resourceType === 'role' &&
+          candidateParts.resourcePath?.split('/').at(-1)?.toLowerCase() === roleName
+        )
+      })
+
+      return matchingRole
+    })
+  }
+
+  /**
    * Checks if a principal exists in the store.
    * @param principalArn The ARN of the principal to check.
    * @returns True if the principal exists, false otherwise.
@@ -255,13 +309,7 @@ export class IamCollectClient {
   async principalExists(principalArn: string): Promise<boolean> {
     const cacheKey = `principalExists:${principalArn}`
     return this.withCache(cacheKey, async () => {
-      const accountId = splitArnParts(principalArn).accountId!
-      const principalData = await this.storageClient.getResourceMetadata(
-        accountId,
-        principalArn,
-        'metadata'
-      )
-      return !!principalData
+      return !!(await this.resolvePrincipalArn(principalArn))
     })
   }
 

--- a/src/principals.test.ts
+++ b/src/principals.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
-import { isServiceLinkedRole } from './principals.js'
+import { testStore } from './collect/inMemoryClient.js'
+import { getAllPoliciesForPrincipal, isServiceLinkedRole } from './principals.js'
+import { saveRole } from './utils/testUtils.js'
 
 describe('isServiceLinkedRole', () => {
   it('should return true for service-linked role ARNs', () => {
@@ -34,5 +36,35 @@ describe('isServiceLinkedRole', () => {
 
     //Then it should return false
     expect(result).toBe(false)
+  })
+})
+
+describe('getAllPoliciesForPrincipal', () => {
+  it('should load policies from a path-qualified role for a pathless assumed-role ARN', async () => {
+    //Given a path-qualified role and an assumed-role session ARN that omits the IAM role path
+    const { store, client } = testStore()
+    const accountId = '123456789012'
+    const roleArn = `arn:aws:iam::${accountId}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_engineer_abcdef1234567890`
+    await saveRole(store, {
+      arn: roleArn,
+      inlinePolicies: [
+        {
+          PolicyName: 'AllowListBucket',
+          PolicyDocument: {
+            Version: '2012-10-17',
+            Statement: [{ Effect: 'Allow', Action: 's3:ListBucket', Resource: '*' }]
+          }
+        }
+      ],
+      managedPolicies: []
+    })
+    const assumedRoleArn = `arn:aws:sts::${accountId}:assumed-role/AWSReservedSSO_engineer_abcdef1234567890/session`
+
+    //When loading policies for the assumed-role session principal
+    const policies = await getAllPoliciesForPrincipal(client, assumedRoleArn)
+
+    //Then the path-qualified role policies should be loaded
+    expect(policies.inlinePolicies).toHaveLength(1)
+    expect(policies.inlinePolicies[0].name).toBe('AllowListBucket')
   })
 })

--- a/src/principals.ts
+++ b/src/principals.ts
@@ -92,6 +92,16 @@ export async function getAllPoliciesForRole(
   }
 }
 
+/**
+ * Get all IAM policies for a supported principal.
+ *
+ * IAM role and assumed-role principals are resolved to their canonical stored ARN before
+ * loading policies so pathless STS session principals can use path-qualified IAM role data.
+ *
+ * @param collectClient the IAM collect client to use for retrieving policies
+ * @param principalArn the ARN or service principal to get policies for
+ * @returns all policies that apply directly to the principal
+ */
 export async function getAllPoliciesForPrincipal(
   collectClient: IamCollectClient,
   principalArn: string
@@ -114,9 +124,12 @@ export async function getAllPoliciesForPrincipal(
   if (isIamUserArn(principalArn)) {
     return getAllPoliciesForUser(collectClient, principalArn)
   } else if (isIamRoleArn(principalArn)) {
-    return getAllPoliciesForRole(collectClient, principalArn)
+    const roleArn = (await collectClient.resolvePrincipalArn(principalArn)) ?? principalArn
+    return getAllPoliciesForRole(collectClient, roleArn)
   } else if (isAssumedRoleArn(principalArn)) {
-    const roleArn = convertAssumedRoleArnToRoleArn(principalArn)
+    const roleArn =
+      (await collectClient.resolvePrincipalArn(principalArn)) ??
+      convertAssumedRoleArnToRoleArn(principalArn)
     return getAllPoliciesForRole(collectClient, roleArn)
   }
   throw new Error(`Unsupported principal type: ${principalArn}`)

--- a/src/test-datasets/iam-data-1/aws/aws/accounts/200000000002/s3/who-can-session-pathless/metadata.json
+++ b/src/test-datasets/iam-data-1/aws/aws/accounts/200000000002/s3/who-can-session-pathless/metadata.json
@@ -1,0 +1,5 @@
+{
+  "name": "who-can-session-pathless",
+  "owner": "200000000002",
+  "arn": "arn:aws:s3:::who-can-session-pathless"
+}

--- a/src/test-datasets/iam-data-1/aws/aws/accounts/200000000002/s3/who-can-session-pathless/policy.json
+++ b/src/test-datasets/iam-data-1/aws/aws/accounts/200000000002/s3/who-can-session-pathless/policy.json
@@ -1,0 +1,16 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowPathQualifiedRoleSessionWithoutPath",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+          "arn:aws:sts::100000000001:assumed-role/AWSReservedSSO_AdministratorAccess_0fed56ec5d997fc5/session-abc"
+        ]
+      },
+      "Action": ["s3:ListBucket"],
+      "Resource": ["arn:aws:s3:::who-can-session-pathless"]
+    }
+  ]
+}

--- a/src/test-datasets/iam-data-1/aws/aws/indexes/buckets-to-accounts.json
+++ b/src/test-datasets/iam-data-1/aws/aws/indexes/buckets-to-accounts.json
@@ -55,6 +55,10 @@
     "accountId": "200000000002",
     "region": "us-west-2"
   },
+  "who-can-session-pathless": {
+    "accountId": "200000000002",
+    "region": "us-west-2"
+  },
   "eu-example-data-lake": {
     "accountId": "100000000001",
     "region": "us-west-2"

--- a/src/whoCan/WhoCanProcessor.ts
+++ b/src/whoCan/WhoCanProcessor.ts
@@ -1105,8 +1105,8 @@ export class WhoCanProcessor {
               isIamRoleArn(principal) ||
               isAssumedRoleArn(principal)
             ) {
-              const principalExists = await collectClient.principalExists(principal)
-              if (!principalExists) {
+              const resolvedPrincipal = await collectClient.resolvePrincipalArn(principal)
+              if (!resolvedPrincipal) {
                 state.principalsNotFound.push(principal)
               } else {
                 for (const action of actions) {
@@ -1114,6 +1114,7 @@ export class WhoCanProcessor {
                     resource,
                     action,
                     principal,
+                    resultPrincipal: resolvedPrincipal,
                     resourceAccount,
                     strictContextKeys: state.request.strictContextKeys,
                     collectDenyDetails: !!state.denyDetailsCallback

--- a/src/whoCan/WhoCanWorker.ts
+++ b/src/whoCan/WhoCanWorker.ts
@@ -17,6 +17,7 @@ export interface WhoCanWorkItem {
   resourceAccount: string | undefined
   action: string
   principal: string
+  resultPrincipal?: string | undefined
   strictContextKeys: string[] | undefined
   collectDenyDetails: boolean
 }
@@ -231,12 +232,12 @@ function mapSimulationResultToWhoCanExecutionResult(
   collectDenyDetails: boolean,
   collectGrantDetails: boolean
 ): WhoCanExecutionResult {
-  const { principal } = workItem
+  const { principal, resultPrincipal } = workItem
 
   if (simulationResponse.overallResult === 'Allowed') {
     // Build allowed result
     const allowed: WhoCanAllowed = {
-      principal,
+      principal: resultPrincipal ?? principal,
       service,
       action,
       level: actionType.toLowerCase()

--- a/src/whoCan/whoCanIntegration.test.ts
+++ b/src/whoCan/whoCanIntegration.test.ts
@@ -373,6 +373,44 @@ const whoCanIntegrationTests: WhoCanIntegrationTest[] = [
     }
   },
   {
+    name: 'path-qualified role referenced by pathless session ARN resolves to role ARN',
+    description:
+      'Resource policy grants a pathless STS assumed-role session ARN. The matching IAM role is stored with an aws-reserved SSO path, and the whoCan result should use that path-qualified role ARN.',
+    data: '1',
+    request: {
+      resource: 'arn:aws:s3:::who-can-session-pathless',
+      actions: ['s3:ListBucket']
+    },
+    expected: {
+      who: [
+        {
+          action: 'ListBucket',
+          principal:
+            'arn:aws:iam::100000000001:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_AdministratorAccess_0fed56ec5d997fc5',
+          service: 's3',
+          level: 'list',
+          resourceType: 'bucket',
+          dependsOnSessionName: true
+        },
+        {
+          action: 'ListBucket',
+          level: 'list',
+          principal: 'arn:aws:iam::200000000002:role/S3CrossAccountRole',
+          service: 's3',
+          resourceType: 'bucket'
+        },
+        {
+          action: 'ListBucket',
+          principal: 'arn:aws:iam::200000000002:user/user1',
+          service: 's3',
+          level: 'list',
+          resourceType: 'bucket'
+        }
+      ],
+      principalsNotFound: []
+    }
+  },
+  {
     name: 'S3 object wildcard (prefix)',
     simulationCounts: { withoutIndex: 3, withIndex: 3 },
     data: '1',


### PR DESCRIPTION
## Summary
- resolve pathless STS assumed-role session principals to the canonical collected IAM role ARN by same-account role name
- keep the session-derived principal for simulation matching while reporting the resolved path-qualified role ARN in who-can results
- add an end-to-end who-can integration fixture/test for a resource policy referencing a path-qualified SSO role via pathless session ARN
