### PR TITLE
feat: add principal-aware permission sets

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,10 +50,13 @@ export {
   PermissionSet,
   buildPermissionSetFromPolicies,
   addPoliciesToPermissionSet,
-  toPolicyStatements
+  toPolicyStatements,
+  type AddStatementToPermissionSetOptions
 } from './principalCan/permissionSet.js'
 export {
   Permission,
   type PermissionEffect,
-  type PermissionConditions
+  type PermissionConditions,
+  type PermissionPrincipals,
+  type PermissionPrincipalType
 } from './principalCan/permission.js'

--- a/src/principalCan/permission.ts
+++ b/src/principalCan/permission.ts
@@ -1,3 +1,17 @@
+import {
+  intersectPrincipalConstraints,
+  normalizePrincipalConstraint,
+  principalArgsForConstraint,
+  principalConstraintsOverlap,
+  principalIncludes,
+  subtractPrincipalConstraint,
+  unionPrincipalConstraints,
+  type PermissionPrincipals,
+  type PrincipalConstraint
+} from './principalConstraints.js'
+
+export type { PermissionPrincipals, PermissionPrincipalType } from './principalConstraints.js'
+
 export type PermissionEffect = 'Allow' | 'Deny'
 
 export type PermissionConditions = Record<string, Record<string, string[]>>
@@ -24,13 +38,25 @@ export class Permission {
     public readonly action: string,
     public readonly resource: string[] | undefined,
     public readonly notResource: string[] | undefined,
-    public readonly conditions: Record<string, Record<string, string[]>> | undefined
+    public readonly conditions: Record<string, Record<string, string[]>> | undefined,
+    public readonly principal: PermissionPrincipals | undefined = undefined,
+    public readonly notPrincipal: PermissionPrincipals | undefined = undefined
   ) {
     if (resource !== undefined && notResource !== undefined) {
       throw new Error('Permission must have a resource or notResource, not both.')
     } else if (resource === undefined && notResource === undefined) {
       throw new Error('Permission must have a resource or notResource, one must be defined.')
     }
+    normalizePrincipalConstraint(principal, notPrincipal)
+  }
+
+  /**
+   * Return this permission's principal constraint normalized for set algebra.
+   *
+   * @returns The normalized principal constraint.
+   */
+  public principalConstraint(): PrincipalConstraint {
+    return normalizePrincipalConstraint(this.principal, this.notPrincipal)
   }
 
   /**
@@ -44,6 +70,10 @@ export class Permission {
       this.service !== other.service ||
       this.action !== other.action
     ) {
+      return false
+    }
+
+    if (!principalIncludes(this.principalConstraint(), other.principalConstraint())) {
       return false
     }
 
@@ -190,6 +220,15 @@ export class Permission {
       return [this, other]
     }
 
+    const principalUnions = unionPrincipalConstraints(
+      this.principalConstraint(),
+      other.principalConstraint()
+    )
+    if (principalUnions.length !== 1) {
+      return [this, other]
+    }
+    const principalArgs = principalArgsForConstraint(principalUnions[0])
+
     // 4. Combine resource/notResource (constructor enforces exclusivity)
     const thisResource = this.resource
     const thisNotResource = this.notResource
@@ -203,25 +242,83 @@ export class Permission {
     // Both have resource[]
     if (thisResource !== undefined && otherResource !== undefined) {
       const union = Array.from(new Set([...thisResource, ...otherResource]))
-      return [new Permission(eff, svc, act, union, undefined, conds)]
+      return [
+        new Permission(
+          eff,
+          svc,
+          act,
+          union,
+          undefined,
+          conds,
+          principalArgs.principal,
+          principalArgs.notPrincipal
+        )
+      ]
     }
     // Both have notResource[]
     if (thisNotResource !== undefined && otherNotResource !== undefined) {
       // Intersection of both notResource arrays
       const intersection = thisNotResource.filter((n) => otherNotResource.includes(n))
-      return [new Permission(eff, svc, act, undefined, intersection, conds)]
+      return [
+        new Permission(
+          eff,
+          svc,
+          act,
+          undefined,
+          intersection,
+          conds,
+          principalArgs.principal,
+          principalArgs.notPrincipal
+        )
+      ]
     }
     // One has resource, other has notResource
     if (thisResource !== undefined && otherNotResource !== undefined) {
       return [
-        new Permission(eff, svc, act, thisResource, undefined, conds),
-        new Permission(eff, svc, act, undefined, otherNotResource, conds)
+        new Permission(
+          eff,
+          svc,
+          act,
+          thisResource,
+          undefined,
+          conds,
+          principalArgs.principal,
+          principalArgs.notPrincipal
+        ),
+        new Permission(
+          eff,
+          svc,
+          act,
+          undefined,
+          otherNotResource,
+          conds,
+          principalArgs.principal,
+          principalArgs.notPrincipal
+        )
       ]
     }
     if (otherResource !== undefined && thisNotResource !== undefined) {
       return [
-        new Permission(eff, svc, act, otherResource, undefined, conds),
-        new Permission(eff, svc, act, undefined, thisNotResource, conds)
+        new Permission(
+          eff,
+          svc,
+          act,
+          otherResource,
+          undefined,
+          conds,
+          principalArgs.principal,
+          principalArgs.notPrincipal
+        ),
+        new Permission(
+          eff,
+          svc,
+          act,
+          undefined,
+          thisNotResource,
+          conds,
+          principalArgs.principal,
+          principalArgs.notPrincipal
+        )
       ]
     }
 
@@ -230,12 +327,48 @@ export class Permission {
   }
 
   /**
-   * Returns the intersection of this Permission with another.
-   * Always returns exactly one Permission. If there is no overlap,
-   * returns undefined.
+   * Returns all representable intersections of this Permission with another.
    *
    * @param other The other Permission to intersect with.
-   * @returns A new Permission representing the intersection of other and this, or undefined if there is no intersection.
+   * @returns New Permissions representing the overlap, or an empty array if there is no intersection.
+   */
+  public intersections(other: Permission): Permission[] {
+    const principalIntersections = intersectPrincipalConstraints(
+      this.principalConstraint(),
+      other.principalConstraint()
+    )
+    const results: Permission[] = []
+
+    for (const principalIntersection of principalIntersections) {
+      const principalArgs = principalArgsForConstraint(principalIntersection)
+      const permissionWithIntersectionPrincipal = new Permission(
+        this.effect,
+        this.service,
+        this.action,
+        this.resource,
+        this.notResource,
+        this.conditions,
+        principalArgs.principal,
+        principalArgs.notPrincipal
+      )
+      const intersection = permissionWithIntersectionPrincipal.intersection(other)
+      if (intersection) {
+        results.push(intersection)
+      }
+    }
+
+    return results
+  }
+
+  /**
+   * Returns one intersection of this Permission with another.
+   *
+   * Prefer {@link intersections} when correctness depends on all possible overlaps. This
+   * compatibility method returns at most one Permission and may omit additional representable
+   * intersections if future principal algebra produces multiple principal residuals.
+   *
+   * @param other The other Permission to intersect with.
+   * @returns A new Permission representing one intersection of other and this, or undefined if there is no intersection.
    */
   public intersection(other: Permission): Permission | undefined {
     // 1. Must match effect, service, and action
@@ -247,6 +380,15 @@ export class Permission {
       // No overlap at all—return a "zero-resource" permission
       return undefined
     }
+
+    const principalIntersections = intersectPrincipalConstraints(
+      this.principalConstraint(),
+      other.principalConstraint()
+    )
+    if (principalIntersections.length === 0) {
+      return undefined
+    }
+    const principalArgs = principalArgsForConstraint(principalIntersections[0])
 
     if (this.resource != undefined && other.resource != undefined) {
       // 2. If one includes the other, return the narrower one unless both are NotResource
@@ -382,7 +524,16 @@ export class Permission {
       if (intersectR.length === 0) {
         return undefined
       }
-      return new Permission(eff, svc, act, intersectR, undefined, conds)
+      return new Permission(
+        eff,
+        svc,
+        act,
+        intersectR,
+        undefined,
+        conds,
+        principalArgs.principal,
+        principalArgs.notPrincipal
+      )
     }
 
     // Both have notResource[] => union of exclusions (more restrictive), but remove subsumed patterns
@@ -394,7 +545,16 @@ export class Permission {
         (pat) =>
           !combined.some((otherPat) => otherPat !== pat && wildcardToRegex(otherPat).test(pat))
       )
-      return new Permission(eff, svc, act, undefined, filtered, conds)
+      return new Permission(
+        eff,
+        svc,
+        act,
+        undefined,
+        filtered,
+        conds,
+        principalArgs.principal,
+        principalArgs.notPrincipal
+      )
     }
 
     // One has resource, other has notResource
@@ -408,7 +568,16 @@ export class Permission {
       if (filtered.length === 0) {
         return undefined
       }
-      return new Permission(eff, svc, act, filtered, undefined, conds)
+      return new Permission(
+        eff,
+        svc,
+        act,
+        filtered,
+        undefined,
+        conds,
+        principalArgs.principal,
+        principalArgs.notPrincipal
+      )
     }
 
     // This should never happen
@@ -440,6 +609,11 @@ export class Permission {
     const allowCondsNorm = normalizeConditionKeys(this.conditions || {})
     const denyCondsNorm = normalizeConditionKeys(other.conditions || {})
     const conditionsMatch = JSON.stringify(allowCondsNorm) === JSON.stringify(denyCondsNorm)
+    const allowPrincipalConstraint = this.principalConstraint()
+    const denyPrincipalConstraint = other.principalConstraint()
+    if (!principalConstraintsOverlap(allowPrincipalConstraint, denyPrincipalConstraint)) {
+      return [this]
+    }
 
     const allowResource = this.resource
     const allowNotResource = this.notResource
@@ -449,6 +623,49 @@ export class Permission {
     const eff = this.effect
     const svc = this.service
     const act = this.action
+    const principalResiduals = subtractPrincipalConstraint(
+      allowPrincipalConstraint,
+      denyPrincipalConstraint
+    )
+    const sameResourceShape =
+      JSON.stringify([...(allowResource ?? [])].sort()) ===
+        JSON.stringify([...(denyResource ?? [])].sort()) &&
+      JSON.stringify([...(allowNotResource ?? [])].sort()) ===
+        JSON.stringify([...(denyNotResource ?? [])].sort())
+    const denyFullyCoversPrincipal = principalIncludes(
+      denyPrincipalConstraint,
+      allowPrincipalConstraint
+    )
+    const allowPrincipalArgs = principalArgsForConstraint(allowPrincipalConstraint)
+    const denyPrincipalArgs = principalArgsForConstraint(denyPrincipalConstraint)
+
+    if (!denyFullyCoversPrincipal && sameResourceShape && conditionsMatch) {
+      const principalResidualsEqualAllow =
+        principalResiduals.length === 1 &&
+        JSON.stringify(principalArgsForConstraint(principalResiduals[0])) ===
+          JSON.stringify(allowPrincipalArgs)
+      if (principalResidualsEqualAllow) {
+        return [this, other]
+      }
+
+      return principalResiduals.map((constraint) => {
+        const args = principalArgsForConstraint(constraint)
+        return new Permission(
+          eff,
+          svc,
+          act,
+          allowResource,
+          allowNotResource,
+          this.conditions,
+          args.principal,
+          args.notPrincipal
+        )
+      })
+    }
+
+    if (!denyFullyCoversPrincipal) {
+      return [this, other]
+    }
 
     // Case: Allow.resource & Deny.resource
     if (allowResource !== undefined && denyResource !== undefined) {
@@ -514,12 +731,30 @@ export class Permission {
       const permissionsToReturn: Permission[] = []
       if (allowNoOverlap.length > 0) {
         permissionsToReturn.push(
-          new Permission(eff, svc, act, allowNoOverlap, undefined, this.conditions)
+          new Permission(
+            eff,
+            svc,
+            act,
+            allowNoOverlap,
+            undefined,
+            this.conditions,
+            allowPrincipalArgs.principal,
+            allowPrincipalArgs.notPrincipal
+          )
         )
       }
       if (allowSupersets.length > 0) {
         permissionsToReturn.push(
-          new Permission(eff, svc, act, allowSupersets, undefined, this.conditions)
+          new Permission(
+            eff,
+            svc,
+            act,
+            allowSupersets,
+            undefined,
+            this.conditions,
+            allowPrincipalArgs.principal,
+            allowPrincipalArgs.notPrincipal
+          )
         )
       }
       if (allowMatches.length > 0 || allowSubsets.length > 0) {
@@ -531,14 +766,25 @@ export class Permission {
             act,
             [...allowMatches, ...allowSubsets],
             undefined,
-            this.conditions
+            this.conditions,
+            allowPrincipalArgs.principal,
+            allowPrincipalArgs.notPrincipal
           )
           permissionsToReturn.push(...applyDenyConditionsToAllow(newAllow, other))
         }
       }
       if (denySubsets.length > 0) {
         permissionsToReturn.push(
-          new Permission('Deny', svc, act, denySubsets, undefined, other.conditions)
+          new Permission(
+            'Deny',
+            svc,
+            act,
+            denySubsets,
+            undefined,
+            other.conditions,
+            denyPrincipalArgs.principal,
+            denyPrincipalArgs.notPrincipal
+          )
         )
       }
       return permissionsToReturn
@@ -610,7 +856,16 @@ export class Permission {
       // ExcludedFromDeny: Keep as-is with original conditions (deny doesn't touch these)
       if (excludedFromDeny.length > 0) {
         permissionsToReturn.push(
-          new Permission(eff, svc, act, excludedFromDeny, undefined, this.conditions)
+          new Permission(
+            eff,
+            svc,
+            act,
+            excludedFromDeny,
+            undefined,
+            this.conditions,
+            allowPrincipalArgs.principal,
+            allowPrincipalArgs.notPrincipal
+          )
         )
       }
 
@@ -627,14 +882,25 @@ export class Permission {
               act,
               coveredDenyNotResourcePatterns,
               undefined,
-              this.conditions
+              this.conditions,
+              allowPrincipalArgs.principal,
+              allowPrincipalArgs.notPrincipal
             )
           )
         }
 
         // Second: Apply inverted deny conditions to the superset resources
         if (denyHasConditions && !conditionsMatch) {
-          const supersetAllow = new Permission(eff, svc, act, supersets, undefined, this.conditions)
+          const supersetAllow = new Permission(
+            eff,
+            svc,
+            act,
+            supersets,
+            undefined,
+            this.conditions,
+            allowPrincipalArgs.principal,
+            allowPrincipalArgs.notPrincipal
+          )
           permissionsToReturn.push(...applyDenyConditionsToAllow(supersetAllow, other))
         }
         // If no conditions or conditions match, the superset is fully denied (nothing to add)
@@ -646,7 +912,16 @@ export class Permission {
         // If the conditions match - these are fully denied (drop them)
         if (denyHasConditions && !conditionsMatch) {
           // Different conditions - keep with inverted deny conditions
-          const newAllow = new Permission(eff, svc, act, affectedByDeny, undefined, this.conditions)
+          const newAllow = new Permission(
+            eff,
+            svc,
+            act,
+            affectedByDeny,
+            undefined,
+            this.conditions,
+            allowPrincipalArgs.principal,
+            allowPrincipalArgs.notPrincipal
+          )
           permissionsToReturn.push(...applyDenyConditionsToAllow(newAllow, other))
         }
       }
@@ -710,7 +985,18 @@ export class Permission {
 
       // Same conditions or no deny conditions: simply expand notResource
       if (conditionsMatch || !denyHasConditions) {
-        return [new Permission(eff, svc, act, undefined, expandedNotResource, this.conditions)]
+        return [
+          new Permission(
+            eff,
+            svc,
+            act,
+            undefined,
+            expandedNotResource,
+            this.conditions,
+            allowPrincipalArgs.principal,
+            allowPrincipalArgs.notPrincipal
+          )
+        ]
       }
 
       // Different conditions: handle Subset and NoOverlap cases separately
@@ -726,7 +1012,9 @@ export class Permission {
         act,
         undefined,
         allowNotResource,
-        this.conditions
+        this.conditions,
+        allowPrincipalArgs.principal,
+        allowPrincipalArgs.notPrincipal
       )
       permissionsToReturn.push(...applyDenyConditionsToAllow(originalAllow, other))
 
@@ -745,7 +1033,9 @@ export class Permission {
             act,
             undefined,
             subsetExpandedNotResource,
-            subsetConditions || other.conditions
+            subsetConditions || other.conditions,
+            allowPrincipalArgs.principal,
+            allowPrincipalArgs.notPrincipal
           )
         )
       }
@@ -754,7 +1044,16 @@ export class Permission {
       // (adding new exclusion is always safe, no condition needed)
       if (hasNoOverlapAdditions) {
         permissionsToReturn.push(
-          new Permission(eff, svc, act, undefined, expandedNotResource, this.conditions)
+          new Permission(
+            eff,
+            svc,
+            act,
+            undefined,
+            expandedNotResource,
+            this.conditions,
+            allowPrincipalArgs.principal,
+            allowPrincipalArgs.notPrincipal
+          )
         )
       }
 
@@ -801,7 +1100,18 @@ export class Permission {
       // Handle conditions
       if (!denyHasConditions || conditionsMatch) {
         // No deny conditions or same conditions: apply directly
-        return [new Permission(eff, svc, act, survivingResources, undefined, this.conditions)]
+        return [
+          new Permission(
+            eff,
+            svc,
+            act,
+            survivingResources,
+            undefined,
+            this.conditions,
+            allowPrincipalArgs.principal,
+            allowPrincipalArgs.notPrincipal
+          )
+        ]
       }
 
       // Different conditions: split into two parts
@@ -814,7 +1124,9 @@ export class Permission {
         act,
         undefined,
         allowNotResource,
-        this.conditions
+        this.conditions,
+        allowPrincipalArgs.principal,
+        allowPrincipalArgs.notPrincipal
       )
       permissionsToReturn.push(...applyDenyConditionsToAllow(originalAllow, other))
 
@@ -825,7 +1137,16 @@ export class Permission {
       )
       const part2Conditions = denyConditionCount === 1 ? other.conditions : undefined
       permissionsToReturn.push(
-        new Permission(eff, svc, act, survivingResources, undefined, part2Conditions)
+        new Permission(
+          eff,
+          svc,
+          act,
+          survivingResources,
+          undefined,
+          part2Conditions,
+          allowPrincipalArgs.principal,
+          allowPrincipalArgs.notPrincipal
+        )
       )
 
       return permissionsToReturn
@@ -1324,7 +1645,9 @@ export function applyDenyConditionsToAllow(allow: Permission, deny: Permission):
             allow.action,
             allow.resource,
             allow.notResource,
-            mergedConditions
+            mergedConditions,
+            allow.principal,
+            allow.notPrincipal
           )
         )
       }

--- a/src/principalCan/permissionPrincipals.test.ts
+++ b/src/principalCan/permissionPrincipals.test.ts
@@ -1,0 +1,1133 @@
+import { loadPolicy } from '@cloud-copilot/iam-policy'
+import { describe, expect, it } from 'vitest'
+import {
+  Permission,
+  type PermissionConditions,
+  type PermissionEffect,
+  type PermissionPrincipals
+} from './permission.js'
+import {
+  PermissionSet,
+  addPoliciesToPermissionSet,
+  addStatementToPermissionSet,
+  buildPermissionSetFromPolicies,
+  toPolicyStatements,
+  type AddStatementToPermissionSetOptions
+} from './permissionSet.js'
+import {
+  expectPermissionsToMatch,
+  expectPermissionSetToMatch,
+  type TestPermission
+} from './permissionSetTestUtils.js'
+
+interface TestPermissionInput {
+  effect?: PermissionEffect
+  action?: string
+  resource?: string[]
+  notResource?: string[]
+  conditions?: PermissionConditions
+  principal?: PermissionPrincipals
+  notPrincipal?: PermissionPrincipals
+}
+
+interface PrincipalOperationTest {
+  only?: true
+  name: string
+  permission: TestPermissionInput
+  otherPermission: TestPermissionInput
+}
+
+interface PrincipalIncludesTest extends PrincipalOperationTest {
+  included: boolean
+}
+
+interface PrincipalResultTest extends PrincipalOperationTest {
+  expected: TestPermission[]
+}
+
+interface StatementConversionTest {
+  only?: true
+  name: string
+  rawStatement: Record<string, unknown>
+  permissionSetEffect: PermissionEffect
+  options?: AddStatementToPermissionSetOptions
+  expected: TestPermission[]
+}
+
+interface PolicyConversionTest {
+  only?: true
+  name: string
+  conversionType: 'buildPermissionSetFromPolicies' | 'addPoliciesToPermissionSet'
+  rawStatement: Record<string, unknown>
+  permissionSetEffect: PermissionEffect
+  options?: AddStatementToPermissionSetOptions
+  expected: TestPermission[]
+}
+
+interface ToPolicyStatementsTest {
+  only?: true
+  name: string
+  permissionSetEffect: PermissionEffect
+  permissions: TestPermission[]
+  expectedStatements: unknown[]
+}
+
+const accountId = '111122223333'
+const otherAccountId = '999988887777'
+const roleAdmin = `arn:aws:iam::${accountId}:role/Admin`
+const roleBlocked = `arn:aws:iam::${accountId}:role/Blocked`
+const roleA = `arn:aws:iam::${accountId}:role/A`
+const roleB = `arn:aws:iam::${accountId}:role/B`
+const otherAccountRole = `arn:aws:iam::${otherAccountId}:role/Admin`
+const lambdaService = 'lambda.amazonaws.com'
+const ec2Service = 'ec2.amazonaws.com'
+const federatedProvider = 'arn:aws:iam::111122223333:saml-provider/Corp'
+const otherFederatedProvider = 'arn:aws:iam::111122223333:saml-provider/Other'
+const canonicalUser = '79a59df900b949e55d96a1e698f0example'
+const otherCanonicalUser = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaexample'
+
+const principalIncludesTests: PrincipalIncludesTest[] = [
+  {
+    name: 'legacy unconstrained principal includes a specific AWS role',
+    permission: {},
+    otherPermission: { principal: { AWS: [roleAdmin] } },
+    included: true
+  },
+  {
+    name: 'explicit wildcard Principal includes a service principal',
+    permission: { principal: { wildcard: true } },
+    otherPermission: { principal: { Service: [lambdaService] } },
+    included: true
+  },
+  {
+    name: 'typed AWS wildcard principal includes a service principal for this analysis',
+    permission: { principal: { AWS: ['*'] } },
+    otherPermission: { principal: { Service: [lambdaService] } },
+    included: true
+  },
+  {
+    name: 'account principal includes role principal in the same account',
+    permission: { principal: { AWS: [accountId] } },
+    otherPermission: { principal: { AWS: [roleAdmin] } },
+    included: true
+  },
+  {
+    name: 'account root principal includes role principal in the same account',
+    permission: { principal: { AWS: [`arn:aws:iam::${accountId}:root`] } },
+    otherPermission: { principal: { AWS: [roleAdmin] } },
+    included: true
+  },
+  {
+    name: 'role principal does not include account principal',
+    permission: { principal: { AWS: [roleAdmin] } },
+    otherPermission: { principal: { AWS: [accountId] } },
+    included: false
+  },
+  {
+    name: 'account principal does not include role in a different account',
+    permission: { principal: { AWS: [accountId] } },
+    otherPermission: { principal: { AWS: [otherAccountRole] } },
+    included: false
+  },
+  {
+    name: 'service principal includes the same service principal',
+    permission: { principal: { Service: [lambdaService] } },
+    otherPermission: { principal: { Service: [lambdaService] } },
+    included: true
+  },
+  {
+    name: 'service principal does not include a different service principal',
+    permission: { principal: { Service: [lambdaService] } },
+    otherPermission: { principal: { Service: [ec2Service] } },
+    included: false
+  },
+  {
+    name: 'service principal does not include AWS principal',
+    permission: { principal: { Service: [lambdaService] } },
+    otherPermission: { principal: { AWS: [roleAdmin] } },
+    included: false
+  },
+  {
+    name: 'federated principal includes the same federated provider',
+    permission: { principal: { Federated: [federatedProvider] } },
+    otherPermission: { principal: { Federated: [federatedProvider] } },
+    included: true
+  },
+  {
+    name: 'federated principal does not include a different federated provider',
+    permission: { principal: { Federated: [federatedProvider] } },
+    otherPermission: { principal: { Federated: [otherFederatedProvider] } },
+    included: false
+  },
+  {
+    name: 'canonical user principal includes the same canonical user',
+    permission: { principal: { CanonicalUser: [canonicalUser] } },
+    otherPermission: { principal: { CanonicalUser: [canonicalUser] } },
+    included: true
+  },
+  {
+    name: 'canonical user principal does not include a different canonical user',
+    permission: { principal: { CanonicalUser: [canonicalUser] } },
+    otherPermission: { principal: { CanonicalUser: [otherCanonicalUser] } },
+    included: false
+  },
+  {
+    name: 'specific principal does not include legacy unconstrained principal',
+    permission: { principal: { AWS: [roleAdmin] } },
+    otherPermission: {},
+    included: false
+  },
+  {
+    name: 'NotPrincipal includes a non-excluded AWS role',
+    permission: { notPrincipal: { AWS: [roleBlocked] } },
+    otherPermission: { principal: { AWS: [roleAdmin] } },
+    included: true
+  },
+  {
+    name: 'NotPrincipal does not include its excluded AWS role',
+    permission: { notPrincipal: { AWS: [roleBlocked] } },
+    otherPermission: { principal: { AWS: [roleBlocked] } },
+    included: false
+  },
+  {
+    name: 'NotPrincipal account does not include a role in the excluded account',
+    permission: { notPrincipal: { AWS: [accountId] } },
+    otherPermission: { principal: { AWS: [roleAdmin] } },
+    included: false
+  },
+  {
+    name: 'NotPrincipal AWS role includes a service principal',
+    permission: { notPrincipal: { AWS: [roleBlocked] } },
+    otherPermission: { principal: { Service: [lambdaService] } },
+    included: true
+  },
+  {
+    name: 'specific principal generally does not include NotPrincipal',
+    permission: { principal: { AWS: [roleAdmin] } },
+    otherPermission: { notPrincipal: { AWS: [roleBlocked] } },
+    included: false
+  },
+  {
+    name: 'typed AWS wildcard includes NotPrincipal',
+    permission: { principal: { AWS: ['*'] } },
+    otherPermission: { notPrincipal: { AWS: [roleBlocked] } },
+    included: true
+  },
+  {
+    name: 'NotPrincipal includes an equally excluded NotPrincipal',
+    permission: { notPrincipal: { AWS: [roleA] } },
+    otherPermission: { notPrincipal: { AWS: [roleA] } },
+    included: true
+  },
+  {
+    name: 'NotPrincipal with fewer exclusions includes NotPrincipal with more exclusions',
+    permission: { notPrincipal: { AWS: [roleA] } },
+    otherPermission: { notPrincipal: { AWS: [roleA, roleB] } },
+    included: true
+  },
+  {
+    name: 'NotPrincipal with more exclusions does not include NotPrincipal with fewer exclusions',
+    permission: { notPrincipal: { AWS: [roleA, roleB] } },
+    otherPermission: { notPrincipal: { AWS: [roleA] } },
+    included: false
+  },
+  {
+    name: 'NotPrincipal role includes NotPrincipal account when the role is inside the account exclusion',
+    permission: { notPrincipal: { AWS: [roleA] } },
+    otherPermission: { notPrincipal: { AWS: [accountId] } },
+    included: true
+  },
+  {
+    name: 'NotPrincipal account does not include NotPrincipal role in that account',
+    permission: { notPrincipal: { AWS: [accountId] } },
+    otherPermission: { notPrincipal: { AWS: [roleA] } },
+    included: false
+  }
+]
+
+const principalUnionTests: PrincipalResultTest[] = [
+  {
+    name: 'keeps legacy unconstrained principal when unioned with a specific principal',
+    permission: {},
+    otherPermission: { principal: { AWS: [roleAdmin] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*']
+      }
+    ]
+  },
+  {
+    name: 'keeps explicit wildcard principal when unioned with a service principal',
+    permission: { principal: { wildcard: true } },
+    otherPermission: { principal: { Service: [lambdaService] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        principal: { wildcard: true }
+      }
+    ]
+  },
+  {
+    name: 'keeps account principal when unioned with a role in the same account',
+    permission: { principal: { AWS: [accountId] } },
+    otherPermission: { principal: { AWS: [roleAdmin] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        principal: { AWS: [accountId] }
+      }
+    ]
+  },
+  {
+    name: 'unions account principal with a role in a different account',
+    permission: { principal: { AWS: [accountId] } },
+    otherPermission: { principal: { AWS: [otherAccountRole] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        principal: { AWS: [accountId, otherAccountRole] }
+      }
+    ]
+  },
+  {
+    name: 'unions permissions with different positive principal types',
+    permission: { principal: { AWS: [accountId] } },
+    otherPermission: { principal: { Service: [lambdaService] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        principal: { AWS: [accountId], Service: [lambdaService] }
+      }
+    ]
+  },
+  {
+    name: 'unions federated and canonical user principal types',
+    permission: { principal: { Federated: [federatedProvider] } },
+    otherPermission: { principal: { CanonicalUser: [canonicalUser] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        principal: { Federated: [federatedProvider], CanonicalUser: [canonicalUser] }
+      }
+    ]
+  },
+  {
+    name: 'unions two service principals into one service principal list',
+    permission: { principal: { Service: [lambdaService] } },
+    otherPermission: { principal: { Service: [ec2Service] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        principal: { Service: [lambdaService, ec2Service] }
+      }
+    ]
+  },
+  {
+    name: 'keeps a NotPrincipal permission when unioned with an already-included positive principal',
+    permission: { principal: { AWS: [roleAdmin] } },
+    otherPermission: { notPrincipal: { AWS: [roleBlocked] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        notPrincipal: { AWS: [roleBlocked] }
+      }
+    ]
+  },
+  {
+    name: 'unions positive principal with NotPrincipal that excludes that principal into wildcard',
+    permission: { principal: { AWS: [roleA] } },
+    otherPermission: { notPrincipal: { AWS: [roleA] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        principal: { wildcard: true }
+      }
+    ]
+  },
+  {
+    name: 'unions positive principal with NotPrincipal by removing that exclusion',
+    permission: { principal: { AWS: [roleA] } },
+    otherPermission: { notPrincipal: { AWS: [roleA, roleB] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        notPrincipal: { AWS: [roleB] }
+      }
+    ]
+  },
+  {
+    name: 'unions NotPrincipal constraints by intersecting overlapping exclusions',
+    permission: { notPrincipal: { AWS: [roleA] } },
+    otherPermission: { notPrincipal: { AWS: [roleA, roleB] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        notPrincipal: { AWS: [roleA] }
+      }
+    ]
+  },
+  {
+    name: 'unions NotPrincipal role and account exclusions to the narrower shared exclusion',
+    permission: { notPrincipal: { AWS: [roleA] } },
+    otherPermission: { notPrincipal: { AWS: [accountId] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        notPrincipal: { AWS: [roleA] }
+      }
+    ]
+  },
+  {
+    name: 'unions disjoint NotPrincipal exclusions into wildcard access',
+    permission: { notPrincipal: { AWS: [roleA] } },
+    otherPermission: { notPrincipal: { AWS: [roleB] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        principal: { wildcard: true }
+      }
+    ]
+  }
+]
+
+const principalIntersectionTests: PrincipalResultTest[] = [
+  {
+    name: 'intersects legacy unconstrained principal with a specific principal',
+    permission: {},
+    otherPermission: { principal: { AWS: [roleAdmin] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        principal: { AWS: [roleAdmin] }
+      }
+    ]
+  },
+  {
+    name: 'intersects explicit wildcard principal with a service principal',
+    permission: { principal: { wildcard: true } },
+    otherPermission: { principal: { Service: [lambdaService] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        principal: { Service: [lambdaService] }
+      }
+    ]
+  },
+  {
+    name: 'intersects typed AWS wildcard principal with a service principal',
+    permission: { principal: { AWS: ['*'] } },
+    otherPermission: { principal: { Service: [lambdaService] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        principal: { Service: [lambdaService] }
+      }
+    ]
+  },
+  {
+    name: 'intersects account and role permissions to the role principal',
+    permission: { principal: { AWS: [accountId] } },
+    otherPermission: { principal: { AWS: [roleAdmin] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        principal: { AWS: [roleAdmin] }
+      }
+    ]
+  },
+  {
+    name: 'intersects account root principal with role principal to the role',
+    permission: { principal: { AWS: [`arn:aws:iam::${accountId}:root`] } },
+    otherPermission: { principal: { AWS: [roleAdmin] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        principal: { AWS: [roleAdmin] }
+      }
+    ]
+  },
+  {
+    name: 'intersects account principal with different account role to no permissions',
+    permission: { principal: { AWS: [accountId] } },
+    otherPermission: { principal: { AWS: [otherAccountRole] } },
+    expected: []
+  },
+  {
+    name: 'intersects same service principal to itself',
+    permission: { principal: { Service: [lambdaService] } },
+    otherPermission: { principal: { Service: [lambdaService] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        principal: { Service: [lambdaService] }
+      }
+    ]
+  },
+  {
+    name: 'intersects different service principals to no permissions',
+    permission: { principal: { Service: [lambdaService] } },
+    otherPermission: { principal: { Service: [ec2Service] } },
+    expected: []
+  },
+  {
+    name: 'intersects same federated principal to itself',
+    permission: { principal: { Federated: [federatedProvider] } },
+    otherPermission: { principal: { Federated: [federatedProvider] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        principal: { Federated: [federatedProvider] }
+      }
+    ]
+  },
+  {
+    name: 'intersects different canonical users to no permissions',
+    permission: { principal: { CanonicalUser: [canonicalUser] } },
+    otherPermission: { principal: { CanonicalUser: [otherCanonicalUser] } },
+    expected: []
+  },
+  {
+    name: 'intersects disjoint positive principal types to no permissions',
+    permission: { principal: { AWS: [roleAdmin] } },
+    otherPermission: { principal: { Service: [lambdaService] } },
+    expected: []
+  },
+  {
+    name: 'intersects positive principal with NotPrincipal when the principal is not excluded',
+    permission: { principal: { AWS: [roleAdmin] } },
+    otherPermission: { notPrincipal: { AWS: [roleBlocked] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        principal: { AWS: [roleAdmin] }
+      }
+    ]
+  },
+  {
+    name: 'intersects positive principal with NotPrincipal to no permissions when excluded',
+    permission: { principal: { AWS: [roleBlocked] } },
+    otherPermission: { notPrincipal: { AWS: [roleBlocked] } },
+    expected: []
+  },
+  {
+    name: 'intersects mixed positive principals with NotPrincipal by removing one type',
+    permission: { principal: { AWS: [roleAdmin], Service: [lambdaService] } },
+    otherPermission: { notPrincipal: { Service: [lambdaService] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        principal: { AWS: [roleAdmin] }
+      }
+    ]
+  },
+  {
+    name: 'intersects NotPrincipal constraints by unioning exclusions',
+    permission: { notPrincipal: { AWS: [roleA] } },
+    otherPermission: { notPrincipal: { AWS: [roleB] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        notPrincipal: { AWS: [roleA, roleB] }
+      }
+    ]
+  },
+  {
+    name: 'intersects NotPrincipal role and account exclusions by keeping the broader account exclusion',
+    permission: { notPrincipal: { AWS: [roleA] } },
+    otherPermission: { notPrincipal: { AWS: [accountId] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        notPrincipal: { AWS: [accountId] }
+      }
+    ]
+  }
+]
+
+const principalSubtractTests: PrincipalResultTest[] = [
+  {
+    name: 'subtracts a specific principal from wildcard access',
+    permission: { principal: { wildcard: true } },
+    otherPermission: { effect: 'Deny', principal: { AWS: [roleBlocked] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        notPrincipal: { AWS: [roleBlocked] }
+      }
+    ]
+  },
+  {
+    name: 'subtracts a specific principal from typed AWS wildcard access',
+    permission: { principal: { AWS: ['*'] } },
+    otherPermission: { effect: 'Deny', principal: { AWS: [roleBlocked] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        notPrincipal: { AWS: [roleBlocked] }
+      }
+    ]
+  },
+  {
+    name: 'subtracts a matching specific principal to no permissions',
+    permission: { principal: { AWS: [roleBlocked] } },
+    otherPermission: { effect: 'Deny', principal: { AWS: [roleBlocked] } },
+    expected: []
+  },
+  {
+    name: 'leaves a different specific principal unchanged',
+    permission: { principal: { AWS: [roleAdmin] } },
+    otherPermission: { effect: 'Deny', principal: { AWS: [roleBlocked] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        principal: { AWS: [roleAdmin] }
+      }
+    ]
+  },
+  {
+    name: 'subtracts NotPrincipal from wildcard access as the excluded principal set',
+    permission: { principal: { wildcard: true } },
+    otherPermission: { effect: 'Deny', notPrincipal: { AWS: [roleA] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        principal: { AWS: [roleA] }
+      }
+    ]
+  },
+  {
+    name: 'falls back to Allow plus Deny residual for account minus role in same account',
+    permission: { principal: { AWS: [accountId] } },
+    otherPermission: { effect: 'Deny', principal: { AWS: [roleBlocked] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        principal: { AWS: [accountId] }
+      },
+      {
+        effect: 'Deny',
+        action: 's3:GetObject',
+        resource: ['*'],
+        principal: { AWS: [roleBlocked] }
+      }
+    ]
+  },
+  {
+    name: 'subtracts one principal type from a mixed positive principal set',
+    permission: { principal: { AWS: [accountId], Service: [lambdaService] } },
+    otherPermission: { effect: 'Deny', principal: { Service: [lambdaService] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        principal: { AWS: [accountId] }
+      }
+    ]
+  },
+  {
+    name: 'inverts deny conditions while preserving matched principal constraints',
+    permission: { principal: { AWS: [roleBlocked] } },
+    otherPermission: {
+      effect: 'Deny',
+      principal: { AWS: [roleBlocked] },
+      conditions: { Bool: { 'aws:MultiFactorAuthPresent': ['true'] } }
+    },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        principal: { AWS: [roleBlocked] },
+        conditions: { bool: { 'aws:multifactorauthpresent': ['false'] } }
+      }
+    ]
+  },
+  {
+    name: 'subtracts a service principal from wildcard access',
+    permission: { principal: { wildcard: true } },
+    otherPermission: { effect: 'Deny', principal: { Service: [lambdaService] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        notPrincipal: { Service: [lambdaService] }
+      }
+    ]
+  },
+  {
+    name: 'subtracts a matching service principal to no permissions',
+    permission: { principal: { Service: [lambdaService] } },
+    otherPermission: { effect: 'Deny', principal: { Service: [lambdaService] } },
+    expected: []
+  },
+  {
+    name: 'leaves a different service principal unchanged',
+    permission: { principal: { Service: [lambdaService] } },
+    otherPermission: { effect: 'Deny', principal: { Service: [ec2Service] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        principal: { Service: [lambdaService] }
+      }
+    ]
+  },
+  {
+    name: 'subtracts a matching federated principal to no permissions',
+    permission: { principal: { Federated: [federatedProvider] } },
+    otherPermission: { effect: 'Deny', principal: { Federated: [federatedProvider] } },
+    expected: []
+  },
+  {
+    name: 'leaves a different canonical user principal unchanged',
+    permission: { principal: { CanonicalUser: [canonicalUser] } },
+    otherPermission: { effect: 'Deny', principal: { CanonicalUser: [otherCanonicalUser] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        principal: { CanonicalUser: [canonicalUser] }
+      }
+    ]
+  },
+  {
+    name: 'adds a denied positive principal to NotPrincipal exclusions',
+    permission: { notPrincipal: { AWS: [roleA] } },
+    otherPermission: { effect: 'Deny', principal: { AWS: [roleB] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        notPrincipal: { AWS: [roleA, roleB] }
+      }
+    ]
+  },
+  {
+    name: 'leaves NotPrincipal unchanged when denied positive principal is already excluded',
+    permission: { notPrincipal: { AWS: [roleA] } },
+    otherPermission: { effect: 'Deny', principal: { AWS: [roleA] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        notPrincipal: { AWS: [roleA] }
+      }
+    ]
+  },
+  {
+    name: 'subtracts NotPrincipal from typed AWS wildcard access as the excluded principal set',
+    permission: { principal: { AWS: ['*'] } },
+    otherPermission: { effect: 'Deny', notPrincipal: { AWS: [roleA] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        principal: { AWS: [roleA] }
+      }
+    ]
+  },
+  {
+    name: 'subtracts NotPrincipal from NotPrincipal',
+    permission: { notPrincipal: { AWS: [roleA] } },
+    otherPermission: { effect: 'Deny', notPrincipal: { AWS: [roleB] } },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        principal: { AWS: [roleB] }
+      }
+    ]
+  }
+]
+
+const statementConversionTests: StatementConversionTest[] = [
+  {
+    name: 'ignores principals by default for compatibility',
+    rawStatement: {
+      Effect: 'Allow',
+      Principal: { AWS: roleAdmin },
+      Action: 's3:GetObject',
+      Resource: '*'
+    },
+    permissionSetEffect: 'Allow',
+    expected: [{ effect: 'Allow', action: 's3:GetObject', resource: ['*'] }]
+  },
+  {
+    name: 'preserves Principal when statement conversion opts in',
+    rawStatement: {
+      Effect: 'Allow',
+      Principal: { AWS: roleAdmin },
+      Action: 's3:GetObject',
+      Resource: '*'
+    },
+    permissionSetEffect: 'Allow',
+    options: { includePrincipals: true },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        principal: { AWS: [roleAdmin] }
+      }
+    ]
+  },
+  {
+    name: 'preserves single wildcard Principal distinctly',
+    rawStatement: {
+      Effect: 'Allow',
+      Principal: '*',
+      Action: 's3:GetObject',
+      Resource: '*'
+    },
+    permissionSetEffect: 'Allow',
+    options: { includePrincipals: true },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        principal: { wildcard: true }
+      }
+    ]
+  },
+  {
+    name: 'preserves NotPrincipal when statement conversion opts in',
+    rawStatement: {
+      Effect: 'Deny',
+      NotPrincipal: { Service: 'lambda.amazonaws.com' },
+      Action: 's3:GetObject',
+      Resource: '*'
+    },
+    permissionSetEffect: 'Deny',
+    options: { includePrincipals: true },
+    expected: [
+      {
+        effect: 'Deny',
+        action: 's3:GetObject',
+        resource: ['*'],
+        notPrincipal: { Service: ['lambda.amazonaws.com'] }
+      }
+    ]
+  }
+]
+
+const policyConversionTests: PolicyConversionTest[] = [
+  {
+    name: 'buildPermissionSetFromPolicies passes principal opt-in to statements',
+    conversionType: 'buildPermissionSetFromPolicies',
+    rawStatement: {
+      Effect: 'Allow',
+      Principal: { AWS: roleAdmin },
+      Action: 's3:GetObject',
+      Resource: '*'
+    },
+    permissionSetEffect: 'Allow',
+    options: { includePrincipals: true },
+    expected: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        principal: { AWS: [roleAdmin] }
+      }
+    ]
+  },
+  {
+    name: 'addPoliciesToPermissionSet passes principal opt-in to statements',
+    conversionType: 'addPoliciesToPermissionSet',
+    rawStatement: {
+      Effect: 'Deny',
+      NotPrincipal: { Service: lambdaService },
+      Action: 's3:GetObject',
+      Resource: '*'
+    },
+    permissionSetEffect: 'Deny',
+    options: { includePrincipals: true },
+    expected: [
+      {
+        effect: 'Deny',
+        action: 's3:GetObject',
+        resource: ['*'],
+        notPrincipal: { Service: [lambdaService] }
+      }
+    ]
+  }
+]
+
+const toPolicyStatementTests: ToPolicyStatementsTest[] = [
+  {
+    name: 'omits Principal and NotPrincipal for legacy permissions',
+    permissionSetEffect: 'Allow',
+    permissions: [{ effect: 'Allow', action: 's3:GetObject', resource: ['*'] }],
+    expectedStatements: [
+      {
+        Effect: 'Allow',
+        Action: 's3:GetObject',
+        Resource: ['*']
+      }
+    ]
+  },
+  {
+    name: 'emits Principal in policy statements',
+    permissionSetEffect: 'Allow',
+    permissions: [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: ['*'],
+        principal: { AWS: [roleAdmin] }
+      }
+    ],
+    expectedStatements: [
+      {
+        Effect: 'Allow',
+        Action: 's3:GetObject',
+        Principal: { AWS: roleAdmin },
+        Resource: ['*']
+      }
+    ]
+  },
+  {
+    name: 'emits NotPrincipal in policy statements',
+    permissionSetEffect: 'Deny',
+    permissions: [
+      {
+        effect: 'Deny',
+        action: 's3:GetObject',
+        resource: ['*'],
+        notPrincipal: { Service: ['lambda.amazonaws.com'] }
+      }
+    ],
+    expectedStatements: [
+      {
+        Effect: 'Deny',
+        Action: 's3:GetObject',
+        NotPrincipal: { Service: 'lambda.amazonaws.com' },
+        Resource: ['*']
+      }
+    ]
+  }
+]
+
+describe('Permission principal dimension includes', () => {
+  for (const test of principalIncludesTests) {
+    const func = test.only ? it.only : it
+    func(test.name, () => {
+      //Given two permissions with principal constraints
+      const permission = testPermissionInputToPermission(test.permission)
+      const otherPermission = testPermissionInputToPermission(test.otherPermission)
+
+      //When checking whether one permission includes the other
+      const result = permission.includes(otherPermission)
+
+      //Then the result should match the expected principal inclusion
+      expect(result).toBe(test.included)
+    })
+  }
+})
+
+describe('Permission principal dimension union', () => {
+  for (const test of principalUnionTests) {
+    const func = test.only ? it.only : it
+    func(test.name, () => {
+      //Given two permissions with principal constraints
+      const permission = testPermissionInputToPermission(test.permission)
+      const otherPermission = testPermissionInputToPermission(test.otherPermission)
+
+      //When the permissions are unioned
+      const result = permission.union(otherPermission)
+
+      //Then the resulting permissions should match the expected principal constraints
+      expectPermissionsToMatch(result, test.expected)
+    })
+  }
+})
+
+describe('Permission principal dimension intersections', () => {
+  for (const test of principalIntersectionTests) {
+    const func = test.only ? it.only : it
+    func(test.name, () => {
+      //Given two permissions with principal constraints
+      const permission = testPermissionInputToPermission(test.permission)
+      const otherPermission = testPermissionInputToPermission(test.otherPermission)
+
+      //When the permissions are intersected
+      const result = permission.intersections(otherPermission)
+
+      //Then the resulting permissions should match the expected principal overlap
+      expectPermissionsToMatch(result, test.expected)
+    })
+  }
+})
+
+describe('Permission principal dimension subtract', () => {
+  for (const test of principalSubtractTests) {
+    const func = test.only ? it.only : it
+    func(test.name, () => {
+      //Given an Allow permission and a Deny permission with principal constraints
+      const permission = testPermissionInputToPermission(test.permission)
+      const otherPermission = testPermissionInputToPermission(test.otherPermission)
+
+      //When the Deny permission is subtracted
+      const result = permission.subtract(otherPermission)
+
+      //Then the resulting permissions should match the expected principal residuals
+      expectPermissionsToMatch(result, test.expected)
+    })
+  }
+})
+
+describe('PermissionSet principal-aware statement conversion', () => {
+  for (const test of statementConversionTests) {
+    const func = test.only ? it.only : it
+    func(test.name, async () => {
+      //Given a resource policy statement and a permission set
+      const statement = loadPolicy({
+        Version: '2012-10-17',
+        Statement: test.rawStatement
+      }).statements()[0]
+      const permissionSet = new PermissionSet(test.permissionSetEffect)
+
+      //When the statement is added to the permission set
+      await addStatementToPermissionSet(statement, permissionSet, test.options)
+
+      //Then the permission set should match the expected principal conversion behavior
+      expectPermissionSetToMatch(permissionSet, test.expected)
+    })
+  }
+})
+
+describe('PermissionSet policy-level principal-aware conversion', () => {
+  for (const test of policyConversionTests) {
+    const func = test.only ? it.only : it
+    func(test.name, async () => {
+      //Given a policy and conversion options
+      const policy = loadPolicy({
+        Version: '2012-10-17',
+        Statement: test.rawStatement
+      })
+
+      //When the policy is converted through the requested PermissionSet API
+      const permissionSet =
+        test.conversionType === 'buildPermissionSetFromPolicies'
+          ? await buildPermissionSetFromPolicies(test.permissionSetEffect, [policy], test.options)
+          : new PermissionSet(test.permissionSetEffect)
+      if (test.conversionType === 'addPoliciesToPermissionSet') {
+        await addPoliciesToPermissionSet(
+          permissionSet,
+          test.permissionSetEffect,
+          [policy],
+          test.options
+        )
+      }
+
+      //Then the permission set should preserve principals according to the options
+      expectPermissionSetToMatch(permissionSet, test.expected)
+    })
+  }
+})
+
+describe('PermissionSet principal policy statement output', () => {
+  for (const test of toPolicyStatementTests) {
+    const func = test.only ? it.only : it
+    func(test.name, () => {
+      //Given a permission set with the test permissions
+      const permissionSet = new PermissionSet(test.permissionSetEffect)
+      for (const permission of test.permissions) {
+        permissionSet.addPermission(testPermissionInputToPermission(permission))
+      }
+
+      //When the permission set is converted to policy statements
+      const statements = toPolicyStatements(permissionSet)
+
+      //Then the statements should match the expected principal output
+      expect(statements).toEqual(test.expectedStatements)
+    })
+  }
+})
+
+/**
+ * Convert a test permission input into a Permission with defaults for principal-specific tests.
+ *
+ * @param input - The test input to convert.
+ * @returns A Permission for the test case.
+ */
+function testPermissionInputToPermission(input: TestPermissionInput): Permission {
+  const [service, action] = (input.action ?? 's3:GetObject').split(':')
+  return new Permission(
+    input.effect ?? 'Allow',
+    service,
+    action,
+    input.resource ?? ['*'],
+    input.notResource,
+    input.conditions,
+    input.principal,
+    input.notPrincipal
+  )
+}

--- a/src/principalCan/permissionSet.ts
+++ b/src/principalCan/permissionSet.ts
@@ -1,6 +1,11 @@
 import { expandIamActions, invertIamActions } from '@cloud-copilot/iam-expand'
 import { type Policy, type Statement } from '@cloud-copilot/iam-policy'
-import { Permission, type PermissionEffect } from './permission.js'
+import { Permission, type PermissionEffect, type PermissionPrincipals } from './permission.js'
+import {
+  canonicalPrincipal,
+  principalsFromRawPolicyValue,
+  principalsToPolicyValue
+} from './principalConstraints.js'
 
 /**
  * A permission set will be a collection of permissions for a specific effect (Allow or Deny).
@@ -161,8 +166,8 @@ export class PermissionSet {
 
         for (const thisPermission of thisPermissions) {
           for (const otherPermission of otherPermissions) {
-            const ix = thisPermission.intersection(otherPermission)
-            if (ix) {
+            const intersections = thisPermission.intersections(otherPermission)
+            for (const ix of intersections) {
               result.addPermission(ix)
             }
           }
@@ -302,20 +307,27 @@ export class PermissionSet {
  * Returns a PermissionSet containing one Permission object for each (service, action, resource, notResource, condition)
  * triple where Effect == "Allow".
  */
+export interface AddStatementToPermissionSetOptions {
+  /** Preserve Principal and NotPrincipal values from statements when converting to permissions. */
+  includePrincipals?: boolean
+}
+
 export async function buildPermissionSetFromPolicies(
   effect: PermissionEffect,
-  policies: Policy[]
+  policies: Policy[],
+  options: AddStatementToPermissionSetOptions = {}
 ): Promise<PermissionSet> {
   // We'll collect all "Allow" statements across all policies
   const permissionSet = new PermissionSet(effect)
-  await addPoliciesToPermissionSet(permissionSet, effect, policies)
+  await addPoliciesToPermissionSet(permissionSet, effect, policies, options)
   return permissionSet
 }
 
 export async function addPoliciesToPermissionSet(
   permissionSet: PermissionSet,
   effect: PermissionEffect,
-  policies: Policy[]
+  policies: Policy[],
+  options: AddStatementToPermissionSetOptions = {}
 ): Promise<void> {
   for (const policy of policies) {
     // Each Policy object has a `.statements` array of raw Statement JSON
@@ -325,7 +337,7 @@ export async function addPoliciesToPermissionSet(
       } else if (effect === 'Deny' && !stmt.isDeny()) {
         continue // skip Allow statements if we're building a Deny set
       }
-      await addStatementToPermissionSet(stmt, permissionSet)
+      await addStatementToPermissionSet(stmt, permissionSet, options)
     }
   }
 }
@@ -339,7 +351,8 @@ export async function addPoliciesToPermissionSet(
  */
 export async function addStatementToPermissionSet(
   statement: Statement,
-  permissionSet: PermissionSet
+  permissionSet: PermissionSet,
+  options: AddStatementToPermissionSetOptions = {}
 ) {
   const effect = statement.effect() as PermissionEffect
   let statementActions: string[]
@@ -364,10 +377,56 @@ export async function addStatementToPermissionSet(
       notResource = statement.notResources().map((r) => r.value())
     }
 
+    const { principal, notPrincipal } = principalFieldsFromStatement(statement, options)
+
     permissionSet.addPermission(
-      new Permission(effect, service, actionName, resource, notResource, statement.conditionMap())
+      new Permission(
+        effect,
+        service,
+        actionName,
+        resource,
+        notResource,
+        statement.conditionMap(),
+        principal,
+        notPrincipal
+      )
     )
   }
+}
+
+/**
+ * Extract opt-in Principal or NotPrincipal fields from a statement.
+ *
+ * @param statement the statement to inspect
+ * @param options conversion options controlling principal preservation
+ * @returns principal fields for a Permission constructor
+ */
+function principalFieldsFromStatement(
+  statement: Statement,
+  options: AddStatementToPermissionSetOptions
+): { principal: PermissionPrincipals | undefined; notPrincipal: PermissionPrincipals | undefined } {
+  if (!options.includePrincipals) {
+    return { principal: undefined, notPrincipal: undefined }
+  }
+
+  const rawStatement = statement.toJSON()
+  if (statement.isPrincipalStatement()) {
+    return {
+      principal: statement.hasSingleWildcardPrincipal()
+        ? { wildcard: true }
+        : principalsFromRawPolicyValue(rawStatement.Principal),
+      notPrincipal: undefined
+    }
+  }
+  if (statement.isNotPrincipalStatement()) {
+    return {
+      principal: undefined,
+      notPrincipal: statement.hasSingleWildcardNotPrincipal()
+        ? { wildcard: true }
+        : principalsFromRawPolicyValue(rawStatement.NotPrincipal)
+    }
+  }
+  return { principal: undefined, notPrincipal: undefined }
 }
 
 /**
@@ -400,8 +459,11 @@ function canonicalKey(p: Permission): string {
       )
     : null
 
+  const principal = canonicalPrincipal(p.principal)
+  const notPrincipal = canonicalPrincipal(p.notPrincipal)
+
   // Effect is fixed for the whole PermissionSet, so not needed in the key.
-  return JSON.stringify({ resources, notResource, canonicalCond })
+  return JSON.stringify({ resources, notResource, principal, notPrincipal, canonicalCond })
 }
 
 /**
@@ -413,7 +475,14 @@ function canonicalKey(p: Permission): string {
 export function toPolicyStatements(set: PermissionSet): any {
   const buckets = new Map<
     string,
-    { res?: string[]; notRes?: string[]; cond?: any; actions: string[] }
+    {
+      res?: string[]
+      notRes?: string[]
+      principal?: PermissionPrincipals
+      notPrincipal?: PermissionPrincipals
+      cond?: any
+      actions: string[]
+    }
   >()
 
   for (const perm of set.getAllPermissions()) {
@@ -421,6 +490,8 @@ export function toPolicyStatements(set: PermissionSet): any {
     const bucket = buckets.get(key) ?? {
       res: perm.resource ? [...perm.resource!] : undefined,
       notRes: perm.notResource ? [...perm.notResource!] : undefined,
+      principal: perm.principal,
+      notPrincipal: perm.notPrincipal,
       cond: perm.conditions ? perm.conditions : undefined,
       actions: []
     }
@@ -433,6 +504,16 @@ export function toPolicyStatements(set: PermissionSet): any {
     const value: any = {
       Effect: set.effect,
       Action: b.actions.length === 1 ? b.actions[0] : [...new Set(b.actions)].sort()
+    }
+
+    if (b.principal && b.notPrincipal) {
+      throw new Error('Permission cannot have both Principal and NotPrincipal defined')
+    }
+
+    if (b.principal) {
+      value['Principal'] = principalsToPolicyValue(b.principal)
+    } else if (b.notPrincipal) {
+      value['NotPrincipal'] = principalsToPolicyValue(b.notPrincipal)
     }
 
     if (b.cond) {

--- a/src/principalCan/permissionSetTestUtils.ts
+++ b/src/principalCan/permissionSetTestUtils.ts
@@ -1,5 +1,5 @@
 import { assert, expect } from 'vitest'
-import { Permission, type PermissionConditions } from './permission.js'
+import { Permission, type PermissionConditions, type PermissionPrincipals } from './permission.js'
 import { PermissionSet } from './permissionSet.js'
 
 export interface TestPermission {
@@ -8,6 +8,8 @@ export interface TestPermission {
   resource?: string[]
   notResource?: string[]
   conditions?: PermissionConditions
+  principal?: PermissionPrincipals
+  notPrincipal?: PermissionPrincipals
 }
 
 /**
@@ -53,6 +55,8 @@ export function expectPermissionSetToMatch(
       expect(lowerCaseConditionKeys(actualPerm.conditions)).toEqual(
         lowerCaseConditionKeys(expectedPerm.conditions)
       )
+      expect(actualPerm.principal).toEqual(expectedPerm.principal)
+      expect(actualPerm.notPrincipal).toEqual(expectedPerm.notPrincipal)
     }
   }
 }
@@ -119,6 +123,8 @@ export function expectPermissionsToMatch(
     expect(lowerCaseConditionKeys(actualResult.conditions), message).toEqual(
       lowerCaseConditionKeys(expectedResult.conditions)
     )
+    expect(actualResult.principal, message).toEqual(expectedResult.principal)
+    expect(actualResult.notPrincipal, message).toEqual(expectedResult.notPrincipal)
   }
 }
 
@@ -136,6 +142,8 @@ export function convertTestPermissionToPermission(testPermission: TestPermission
     thisAction,
     testPermission.resource,
     testPermission.notResource,
-    testPermission.conditions
+    testPermission.conditions,
+    testPermission.principal,
+    testPermission.notPrincipal
   )
 }

--- a/src/principalCan/principalConstraints.test.ts
+++ b/src/principalCan/principalConstraints.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from 'vitest'
+import {
+  intersectPrincipalConstraints,
+  normalizePrincipalConstraint,
+  normalizePermissionPrincipals,
+  principalIncludes,
+  subtractPrincipalConstraint,
+  unionPrincipalConstraints
+} from './principalConstraints.js'
+
+describe('normalizePermissionPrincipals', () => {
+  it('should reject wildcard mixed with typed principals', () => {
+    //Given a principal set with a wildcard and typed AWS principal
+    const principals = { wildcard: true as const, AWS: ['arn:aws:iam::111122223333:role/Admin'] }
+
+    //When we normalize the principal set
+    const normalize = () => normalizePermissionPrincipals(principals)
+
+    //Then it should reject the ambiguous input
+    expect(normalize).toThrow('wildcard')
+  })
+
+  it('should normalize STS assumed-role session ARNs to IAM role ARNs', () => {
+    //Given an STS assumed-role session principal
+    const principals = {
+      AWS: ['arn:aws:sts::111122223333:assumed-role/path/to/Admin/session-1']
+    }
+
+    //When the principal set is normalized
+    const result = normalizePermissionPrincipals(principals)
+
+    //Then the principal should be the corresponding IAM role ARN
+    expect(result).toEqual({ AWS: ['arn:aws:iam::111122223333:role/path/to/Admin'] })
+  })
+})
+
+describe('principalIncludes', () => {
+  it('should treat wildcard principals as including service and AWS principals', () => {
+    //Given a wildcard principal constraint and a service principal constraint
+    const wildcard = normalizePrincipalConstraint({ wildcard: true }, undefined)
+    const service = normalizePrincipalConstraint({ Service: ['lambda.amazonaws.com'] }, undefined)
+
+    //When checking inclusion
+    const result = principalIncludes(wildcard, service)
+
+    //Then the wildcard should include the service principal
+    expect(result).toBe(true)
+  })
+
+  it('should treat typed AWS wildcard principals as including service principals', () => {
+    //Given a typed AWS wildcard principal and a service principal
+    const typedWildcard = normalizePrincipalConstraint({ AWS: ['*'] }, undefined)
+    const service = normalizePrincipalConstraint({ Service: ['lambda.amazonaws.com'] }, undefined)
+
+    //When checking inclusion
+    const result = principalIncludes(typedWildcard, service)
+
+    //Then the typed AWS wildcard should include the service principal for this analysis
+    expect(result).toBe(true)
+  })
+
+  it('should treat account principals as including role principals in the same account', () => {
+    //Given an account principal and a role principal in that account
+    const account = normalizePrincipalConstraint({ AWS: ['111122223333'] }, undefined)
+    const role = normalizePrincipalConstraint(
+      { AWS: ['arn:aws:iam::111122223333:role/Admin'] },
+      undefined
+    )
+
+    //When checking inclusion
+    const result = principalIncludes(account, role)
+
+    //Then the account principal should include the role principal
+    expect(result).toBe(true)
+  })
+
+  it('should not include a principal excluded by NotPrincipal', () => {
+    //Given a NotPrincipal exclusion and the excluded role principal
+    const notRole = normalizePrincipalConstraint(undefined, {
+      AWS: ['arn:aws:iam::111122223333:role/Blocked']
+    })
+    const blockedRole = normalizePrincipalConstraint(
+      { AWS: ['arn:aws:iam::111122223333:role/Blocked'] },
+      undefined
+    )
+
+    //When checking inclusion
+    const result = principalIncludes(notRole, blockedRole)
+
+    //Then the NotPrincipal constraint should not include the excluded role
+    expect(result).toBe(false)
+  })
+})
+
+describe('principal set operations', () => {
+  it('should union positive principal sets by principal type', () => {
+    //Given two positive principal constraints
+    const first = normalizePrincipalConstraint({ AWS: ['111122223333'] }, undefined)
+    const second = normalizePrincipalConstraint({ Service: ['lambda.amazonaws.com'] }, undefined)
+
+    //When the constraints are unioned
+    const result = unionPrincipalConstraints(first, second)
+
+    //Then the resulting principal constraint should contain both entries
+    expect(result).toEqual([
+      {
+        kind: 'principal',
+        principals: { AWS: ['111122223333'], Service: ['lambda.amazonaws.com'] }
+      }
+    ])
+  })
+
+  it('should intersect an account principal with a role principal to the role principal', () => {
+    //Given an account principal and a role principal in the account
+    const account = normalizePrincipalConstraint({ AWS: ['111122223333'] }, undefined)
+    const role = normalizePrincipalConstraint(
+      { AWS: ['arn:aws:iam::111122223333:role/Admin'] },
+      undefined
+    )
+
+    //When the constraints are intersected
+    const result = intersectPrincipalConstraints(account, role)
+
+    //Then the role principal should remain as the narrower intersection
+    expect(result).toEqual([
+      { kind: 'principal', principals: { AWS: ['arn:aws:iam::111122223333:role/Admin'] } }
+    ])
+  })
+
+  it('should intersect typed AWS wildcard with a specific role to the role principal', () => {
+    //Given a typed AWS wildcard and a specific role principal
+    const typedWildcard = normalizePrincipalConstraint({ AWS: ['*'] }, undefined)
+    const role = normalizePrincipalConstraint(
+      { AWS: ['arn:aws:iam::111122223333:role/Admin'] },
+      undefined
+    )
+
+    //When the constraints are intersected
+    const result = intersectPrincipalConstraints(typedWildcard, role)
+
+    //Then the specific role should remain as the narrower intersection
+    expect(result).toEqual([
+      { kind: 'principal', principals: { AWS: ['arn:aws:iam::111122223333:role/Admin'] } }
+    ])
+  })
+
+  it('should subtract a specific principal from wildcard as NotPrincipal', () => {
+    //Given wildcard access and a denied role principal
+    const wildcard = normalizePrincipalConstraint({ wildcard: true }, undefined)
+    const role = normalizePrincipalConstraint(
+      { AWS: ['arn:aws:iam::111122223333:role/Blocked'] },
+      undefined
+    )
+
+    //When the role is subtracted
+    const result = subtractPrincipalConstraint(wildcard, role)
+
+    //Then the residual should be everyone except the denied role
+    expect(result).toEqual([
+      {
+        kind: 'notPrincipal',
+        principals: { AWS: ['arn:aws:iam::111122223333:role/Blocked'] }
+      }
+    ])
+  })
+
+  it('should subtract a specific principal from typed AWS wildcard as NotPrincipal', () => {
+    //Given typed AWS wildcard access and a denied role principal
+    const typedWildcard = normalizePrincipalConstraint({ AWS: ['*'] }, undefined)
+    const role = normalizePrincipalConstraint(
+      { AWS: ['arn:aws:iam::111122223333:role/Blocked'] },
+      undefined
+    )
+
+    //When the role is subtracted
+    const result = subtractPrincipalConstraint(typedWildcard, role)
+
+    //Then the residual should be everyone except the denied role
+    expect(result).toEqual([
+      {
+        kind: 'notPrincipal',
+        principals: { AWS: ['arn:aws:iam::111122223333:role/Blocked'] }
+      }
+    ])
+  })
+
+  it('should subtract NotPrincipal from NotPrincipal as the remaining positive principals', () => {
+    //Given an allow for everyone except role A and a deny for everyone except role B
+    const allow = normalizePrincipalConstraint(undefined, {
+      AWS: ['arn:aws:iam::111122223333:role/A']
+    })
+    const deny = normalizePrincipalConstraint(undefined, {
+      AWS: ['arn:aws:iam::111122223333:role/B']
+    })
+
+    //When the deny is subtracted from the allow
+    const result = subtractPrincipalConstraint(allow, deny)
+
+    //Then only role B remains allowed
+    expect(result).toEqual([
+      { kind: 'principal', principals: { AWS: ['arn:aws:iam::111122223333:role/B'] } }
+    ])
+  })
+})

--- a/src/principalCan/principalConstraints.ts
+++ b/src/principalCan/principalConstraints.ts
@@ -1,0 +1,552 @@
+import { splitArnParts } from '@cloud-copilot/iam-utils'
+
+/** IAM principal type keys supported in Principal and NotPrincipal policy elements. */
+export type PermissionPrincipalType = 'AWS' | 'Service' | 'Federated' | 'CanonicalUser'
+
+/** Principal values grouped by IAM principal type for Permission algebra and policy output. */
+export type PermissionPrincipals = Partial<Record<PermissionPrincipalType, string[]>> & {
+  /** True when the policy used Principal: "*" rather than a typed principal map. */
+  wildcard?: true
+}
+
+/** Internal normalized representation of a Principal or NotPrincipal dimension. */
+export type PrincipalConstraint =
+  | { kind: 'any'; explicit: boolean }
+  | { kind: 'principal'; principals: PermissionPrincipals }
+  | { kind: 'notPrincipal'; principals: PermissionPrincipals }
+
+/** A normalized principal entry with semantic scope metadata used for comparisons. */
+export interface NormalizedPrincipalEntry {
+  /** The IAM principal type or Any for Principal: "*". */
+  type: PermissionPrincipalType | 'Any'
+  /** The normalized string value retained for round-tripping and debugging. */
+  value: string
+  /** The semantic category used for containment and overlap comparisons. */
+  semanticKind:
+    | 'wildcard'
+    | 'account'
+    | 'arn'
+    | 'service'
+    | 'federated'
+    | 'canonicalUser'
+    | 'organization'
+    | 'network'
+  /** Account IDs covered by this principal or derived principal-related condition scope. */
+  accountIds?: string[]
+  /** Organization IDs covered by this principal-related condition scope. */
+  organizationIds?: string[]
+  /** AWS service principal names covered by this entry. */
+  servicePrincipals?: string[]
+  /** VPC IDs covered by this principal-related condition scope. */
+  vpcIds?: string[]
+  /** CIDR blocks covered by this principal-related condition scope. */
+  cidrBlocks?: string[]
+}
+
+/** The relationship between two normalized principal sets. */
+export type PrincipalSetRelation =
+  'equal' | 'subset' | 'superset' | 'overlap' | 'disjoint' | 'unknown'
+
+const principalTypes: PermissionPrincipalType[] = ['AWS', 'Service', 'Federated', 'CanonicalUser']
+
+/**
+ * Build an unconstrained principal dimension.
+ *
+ * @param explicit - True when the source policy explicitly used Principal: "*".
+ * @returns The unconstrained principal constraint.
+ */
+export function anyPrincipalConstraint(explicit: boolean): PrincipalConstraint {
+  return { kind: 'any', explicit }
+}
+
+/**
+ * Build a positive principal constraint.
+ *
+ * @param principals - The positive principal values.
+ * @returns A normalized principal constraint.
+ */
+export function principalConstraint(
+  principals: PermissionPrincipals | undefined
+): PrincipalConstraint {
+  return normalizePrincipalConstraint(principals, undefined)
+}
+
+/**
+ * Build a negative principal constraint.
+ *
+ * @param notPrincipals - The excluded principal values.
+ * @returns A normalized not-principal constraint.
+ */
+export function notPrincipalConstraint(
+  notPrincipals: PermissionPrincipals | undefined
+): PrincipalConstraint {
+  return normalizePrincipalConstraint(undefined, notPrincipals)
+}
+
+/**
+ * Normalize optional Principal and NotPrincipal values into an internal constraint.
+ *
+ * @param principal - Positive principals, if present.
+ * @param notPrincipal - Negative principals, if present.
+ * @returns The normalized principal constraint.
+ */
+export function normalizePrincipalConstraint(
+  principal: PermissionPrincipals | undefined,
+  notPrincipal: PermissionPrincipals | undefined
+): PrincipalConstraint {
+  if (principal && notPrincipal) {
+    throw new Error('Permission must have a principal or notPrincipal, not both.')
+  }
+  if (principal) {
+    const normalized = normalizePermissionPrincipals(principal)
+    if (normalized.wildcard) return { kind: 'any', explicit: true }
+    return { kind: 'principal', principals: normalized }
+  }
+  if (notPrincipal) {
+    const normalized = normalizePermissionPrincipals(notPrincipal)
+    if (normalized.wildcard) return { kind: 'notPrincipal', principals: normalized }
+    return { kind: 'notPrincipal', principals: normalized }
+  }
+  return { kind: 'any', explicit: false }
+}
+
+/**
+ * Normalize principal values by validating wildcard usage, de-duplicating values, and normalizing STS sessions.
+ *
+ * @param principals - Principal values to normalize.
+ * @returns Normalized principal values.
+ */
+export function normalizePermissionPrincipals(
+  principals: PermissionPrincipals
+): PermissionPrincipals {
+  const hasTypedValues = principalTypes.some((type) => (principals[type]?.length ?? 0) > 0)
+  if (principals.wildcard && hasTypedValues) {
+    throw new Error(
+      'Permission principals cannot combine wildcard: true with typed principal values'
+    )
+  }
+
+  const normalized: PermissionPrincipals = {}
+  if (principals.wildcard) {
+    normalized.wildcard = true
+  }
+  for (const type of principalTypes) {
+    const values = principals[type]
+    if (values && values.length > 0) {
+      normalized[type] = Array.from(
+        new Set(values.map((value) => normalizePrincipalValue(type, value)))
+      )
+    }
+  }
+  if (!normalized.wildcard && principalEntries(normalized).length === 0) {
+    throw new Error('Permission principals must contain at least one principal value')
+  }
+  return normalized
+}
+
+/**
+ * Determine whether one principal constraint fully includes another.
+ *
+ * @param a - Candidate including constraint.
+ * @param b - Candidate included constraint.
+ * @returns True when every principal in b is also in a.
+ */
+export function principalIncludes(a: PrincipalConstraint, b: PrincipalConstraint): boolean {
+  if (a.kind === 'any') return true
+  if (b.kind === 'any') return constraintIsUniversal(a)
+
+  if (a.kind === 'principal' && b.kind === 'principal') {
+    return entriesIncludeAll(principalEntries(a.principals), principalEntries(b.principals))
+  }
+
+  if (a.kind === 'notPrincipal' && b.kind === 'principal') {
+    return principalEntries(b.principals).every(
+      (entry) => !principalEntries(a.principals).some((excluded) => entriesOverlap(excluded, entry))
+    )
+  }
+
+  if (a.kind === 'notPrincipal' && b.kind === 'notPrincipal') {
+    return entriesIncludeAll(principalEntries(b.principals), principalEntries(a.principals))
+  }
+
+  if (a.kind === 'principal' && b.kind === 'notPrincipal') {
+    return constraintIsUniversal(a)
+  }
+
+  return false
+}
+
+/**
+ * Determine whether two principal constraints have any possible overlap.
+ *
+ * @param a - First principal constraint.
+ * @param b - Second principal constraint.
+ * @returns True when at least one principal can satisfy both constraints.
+ */
+export function principalConstraintsOverlap(
+  a: PrincipalConstraint,
+  b: PrincipalConstraint
+): boolean {
+  return intersectPrincipalConstraints(a, b).length > 0
+}
+
+/**
+ * Return compact principal constraints representing a union.
+ *
+ * @param a - First principal constraint.
+ * @param b - Second principal constraint.
+ * @returns One or more constraints representing the union.
+ */
+export function unionPrincipalConstraints(
+  a: PrincipalConstraint,
+  b: PrincipalConstraint
+): PrincipalConstraint[] {
+  if (principalIncludes(a, b)) return [a]
+  if (principalIncludes(b, a)) return [b]
+  if (a.kind === 'any') return [{ kind: 'any', explicit: a.explicit }]
+  if (b.kind === 'any') return [{ kind: 'any', explicit: b.explicit }]
+
+  if (a.kind === 'principal' && b.kind === 'principal') {
+    return [{ kind: 'principal', principals: mergePrincipals(a.principals, b.principals) }]
+  }
+
+  if (a.kind === 'notPrincipal' && b.kind === 'notPrincipal') {
+    const intersection = intersectPrincipalMaps(a.principals, b.principals)
+    return intersection
+      ? [{ kind: 'notPrincipal', principals: intersection }]
+      : [{ kind: 'any', explicit: true }]
+  }
+
+  const positive = a.kind === 'principal' ? a : b.kind === 'principal' ? b : undefined
+  const negative = a.kind === 'notPrincipal' ? a : b.kind === 'notPrincipal' ? b : undefined
+  if (positive && negative) {
+    const remainingExclusions = subtractPrincipalMap(negative.principals, positive.principals)
+    return remainingExclusions
+      ? [{ kind: 'notPrincipal', principals: remainingExclusions }]
+      : [{ kind: 'any', explicit: true }]
+  }
+
+  return [a, b]
+}
+
+/**
+ * Return constraints representing the intersection of two principal constraints.
+ *
+ * @param a - First principal constraint.
+ * @param b - Second principal constraint.
+ * @returns Constraints for the overlap, or an empty array when disjoint.
+ */
+export function intersectPrincipalConstraints(
+  a: PrincipalConstraint,
+  b: PrincipalConstraint
+): PrincipalConstraint[] {
+  if (a.kind === 'any') return [b]
+  if (b.kind === 'any') return [a]
+
+  if (a.kind === 'principal' && b.kind === 'principal') {
+    const intersection = intersectPrincipalMaps(a.principals, b.principals)
+    return intersection ? [{ kind: 'principal', principals: intersection }] : []
+  }
+
+  if (a.kind === 'notPrincipal' && b.kind === 'notPrincipal') {
+    return [{ kind: 'notPrincipal', principals: mergePrincipals(a.principals, b.principals) }]
+  }
+
+  const positive = a.kind === 'principal' ? a : b.kind === 'principal' ? b : undefined
+  const negative = a.kind === 'notPrincipal' ? a : b.kind === 'notPrincipal' ? b : undefined
+  if (positive && negative) {
+    const remaining = subtractPrincipalMap(positive.principals, negative.principals)
+    return remaining ? [{ kind: 'principal', principals: remaining }] : []
+  }
+
+  return []
+}
+
+/**
+ * Return constraints for allow minus deny on the principal dimension.
+ *
+ * @param allow - Allow principal constraint.
+ * @param deny - Deny principal constraint.
+ * @returns Principal constraints that remain allowed.
+ */
+export function subtractPrincipalConstraint(
+  allow: PrincipalConstraint,
+  deny: PrincipalConstraint
+): PrincipalConstraint[] {
+  if (!principalConstraintsOverlap(allow, deny)) return [allow]
+  if (principalIncludes(deny, allow)) return []
+
+  if (constraintIsUniversal(allow) && deny.kind === 'principal') {
+    return [{ kind: 'notPrincipal', principals: deny.principals }]
+  }
+  if (constraintIsUniversal(allow) && deny.kind === 'notPrincipal') {
+    return [{ kind: 'principal', principals: deny.principals }]
+  }
+  if (allow.kind === 'principal' && deny.kind === 'principal') {
+    const remaining = subtractPrincipalMap(allow.principals, deny.principals)
+    return remaining ? [{ kind: 'principal', principals: remaining }] : []
+  }
+  if (allow.kind === 'notPrincipal' && deny.kind === 'principal') {
+    return [
+      { kind: 'notPrincipal', principals: mergePrincipals(allow.principals, deny.principals) }
+    ]
+  }
+  if (allow.kind === 'notPrincipal' && deny.kind === 'notPrincipal') {
+    const remaining = subtractPrincipalMap(deny.principals, allow.principals)
+    return remaining ? [{ kind: 'principal', principals: remaining }] : []
+  }
+
+  return [allow]
+}
+
+/**
+ * Convert a constraint into Permission constructor principal arguments.
+ *
+ * @param constraint - The principal constraint to convert.
+ * @returns Principal and NotPrincipal fields for a Permission.
+ */
+export function principalArgsForConstraint(constraint: PrincipalConstraint): {
+  principal: PermissionPrincipals | undefined
+  notPrincipal: PermissionPrincipals | undefined
+} {
+  if (constraint.kind === 'any') {
+    return {
+      principal: constraint.explicit ? { wildcard: true } : undefined,
+      notPrincipal: undefined
+    }
+  }
+  if (constraint.kind === 'principal') {
+    return { principal: constraint.principals, notPrincipal: undefined }
+  }
+  return { principal: undefined, notPrincipal: constraint.principals }
+}
+
+/**
+ * Convert principal values to a stable JSON value for bucketing policy statements.
+ *
+ * @param principal - Principal values to canonicalize.
+ * @returns A JSON-compatible canonical representation.
+ */
+export function canonicalPrincipal(principal: PermissionPrincipals | undefined): unknown {
+  if (!principal) return null
+  const normalized = normalizePermissionPrincipals(principal)
+  const out: Record<string, string[] | true> = {}
+  if (normalized.wildcard) out.wildcard = true
+  for (const type of principalTypes) {
+    if (normalized[type]) out[type] = [...normalized[type]].sort()
+  }
+  return out
+}
+
+/**
+ * Convert a Principal/NotPrincipal raw policy value into PermissionPrincipals.
+ *
+ * @param value - The raw Principal or NotPrincipal value.
+ * @returns Permission principal values.
+ */
+export function principalsFromRawPolicyValue(value: unknown): PermissionPrincipals | undefined {
+  if (value === undefined) return undefined
+  if (value === '*') return { wildcard: true }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined
+
+  const result: PermissionPrincipals = {}
+  const record = value as Record<string, string | string[]>
+  for (const type of principalTypes) {
+    const rawValues = record[type]
+    if (rawValues === undefined) continue
+    result[type] = Array.isArray(rawValues) ? [...rawValues] : [rawValues]
+  }
+  return normalizePermissionPrincipals(result)
+}
+
+/**
+ * Convert PermissionPrincipals into a raw policy Principal or NotPrincipal value.
+ *
+ * @param principals - Principal values to convert.
+ * @returns A raw policy value.
+ */
+export function principalsToPolicyValue(principals: PermissionPrincipals): unknown {
+  const normalized = normalizePermissionPrincipals(principals)
+  if (normalized.wildcard) return '*'
+
+  const out: Record<string, string | string[]> = {}
+  for (const type of principalTypes) {
+    const values = normalized[type]
+    if (values) out[type] = values.length === 1 ? values[0] : [...values]
+  }
+  return out
+}
+
+function constraintIsUniversal(constraint: PrincipalConstraint): boolean {
+  return (
+    constraint.kind === 'any' ||
+    (constraint.kind === 'principal' && isWildcardPrincipals(constraint.principals))
+  )
+}
+
+function isWildcardPrincipals(principals: PermissionPrincipals): boolean {
+  return principals.wildcard === true || principals.AWS?.includes('*') === true
+}
+
+function principalEntries(principals: PermissionPrincipals): NormalizedPrincipalEntry[] {
+  if (principals.wildcard) return [{ type: 'Any', value: '*', semanticKind: 'wildcard' }]
+  return principalTypes.flatMap((type) =>
+    (principals[type] ?? []).map((value) => entryForValue(type, value))
+  )
+}
+
+function entriesIncludeAll(a: NormalizedPrincipalEntry[], b: NormalizedPrincipalEntry[]): boolean {
+  return b.every((bEntry) => a.some((aEntry) => entryIncludes(aEntry, bEntry)))
+}
+
+function entryIncludes(a: NormalizedPrincipalEntry, b: NormalizedPrincipalEntry): boolean {
+  if (a.semanticKind === 'wildcard') return true
+  if (a.type === 'AWS' && a.value === '*') return true
+  if (a.type !== b.type) return false
+  if (a.value === b.value) return true
+  if (
+    a.semanticKind === 'account' &&
+    b.accountIds?.some((accountId) => a.accountIds?.includes(accountId))
+  ) {
+    return true
+  }
+  return false
+}
+
+function entriesOverlap(a: NormalizedPrincipalEntry, b: NormalizedPrincipalEntry): boolean {
+  return entryIncludes(a, b) || entryIncludes(b, a)
+}
+
+function mergePrincipals(a: PermissionPrincipals, b: PermissionPrincipals): PermissionPrincipals {
+  if (isWildcardPrincipals(a) || isWildcardPrincipals(b))
+    return a.wildcard || b.wildcard ? { wildcard: true } : { AWS: ['*'] }
+  const merged: PermissionPrincipals = {}
+  for (const type of principalTypes) {
+    const values = [...(a[type] ?? []), ...(b[type] ?? [])]
+    if (values.length > 0)
+      merged[type] = Array.from(new Set(values.map((v) => normalizePrincipalValue(type, v))))
+  }
+  return normalizePermissionPrincipals(merged)
+}
+
+function intersectPrincipalMaps(
+  a: PermissionPrincipals,
+  b: PermissionPrincipals
+): PermissionPrincipals | undefined {
+  if (isWildcardPrincipals(a)) return b
+  if (isWildcardPrincipals(b)) return a
+  const entriesA = principalEntries(a)
+  const entriesB = principalEntries(b)
+  const kept: NormalizedPrincipalEntry[] = []
+  for (const aEntry of entriesA) {
+    for (const bEntry of entriesB) {
+      const intersection = intersectEntries(aEntry, bEntry)
+      if (intersection) kept.push(intersection)
+    }
+  }
+  return principalsFromEntries(kept)
+}
+
+function subtractPrincipalMap(
+  source: PermissionPrincipals,
+  remove: PermissionPrincipals
+): PermissionPrincipals | undefined {
+  if (isWildcardPrincipals(remove)) return undefined
+  // Universal-source subtraction that needs a NotPrincipal residual is handled by
+  // subtractPrincipalConstraint before this positive-map helper is called.
+  if (isWildcardPrincipals(source)) return source
+  const removeEntries = principalEntries(remove)
+  const kept = principalEntries(source).filter(
+    (entry) => !removeEntries.some((removeEntry) => entryIncludes(removeEntry, entry))
+  )
+  return principalsFromEntries(kept)
+}
+
+function intersectEntries(
+  a: NormalizedPrincipalEntry,
+  b: NormalizedPrincipalEntry
+): NormalizedPrincipalEntry | undefined {
+  if (!entriesOverlap(a, b)) return undefined
+  if (entryIncludes(a, b)) return b
+  if (entryIncludes(b, a)) return a
+  return undefined
+}
+
+function principalsFromEntries(
+  entries: NormalizedPrincipalEntry[]
+): PermissionPrincipals | undefined {
+  const out: PermissionPrincipals = {}
+  for (const entry of entries) {
+    if (entry.semanticKind === 'wildcard') return { wildcard: true }
+    if (entry.type === 'Any') return { wildcard: true }
+    const type = entry.type
+    out[type] = [...(out[type] ?? []), entry.value]
+  }
+  for (const type of principalTypes) {
+    if (out[type]) out[type] = Array.from(new Set(out[type]))
+  }
+  return principalEntries(out).length > 0 ? normalizePermissionPrincipals(out) : undefined
+}
+
+function entryForValue(type: PermissionPrincipalType, value: string): NormalizedPrincipalEntry {
+  const normalizedValue = normalizePrincipalValue(type, value)
+  if (normalizedValue === '*') return { type, value: normalizedValue, semanticKind: 'wildcard' }
+  if (type === 'AWS') {
+    const accountId = accountIdForAwsPrincipal(normalizedValue)
+    if (/^\d{12}$/.test(normalizedValue) || normalizedValue.endsWith(':root')) {
+      return {
+        type,
+        value: normalizedValue,
+        semanticKind: 'account',
+        accountIds: accountId ? [accountId] : undefined
+      }
+    }
+    return {
+      type,
+      value: normalizedValue,
+      semanticKind: 'arn',
+      accountIds: accountId ? [accountId] : undefined
+    }
+  }
+  if (type === 'Service') {
+    return {
+      type,
+      value: normalizedValue,
+      semanticKind: 'service',
+      servicePrincipals: [normalizedValue]
+    }
+  }
+  if (type === 'Federated') return { type, value: normalizedValue, semanticKind: 'federated' }
+  return { type, value: normalizedValue, semanticKind: 'canonicalUser' }
+}
+
+function normalizePrincipalValue(type: PermissionPrincipalType, value: string): string {
+  if (type !== 'AWS') return value
+  return normalizeStsAssumedRoleArn(value)
+}
+
+function accountIdForAwsPrincipal(value: string): string | undefined {
+  if (/^\d{12}$/.test(value)) return value
+  if (!value.startsWith('arn:')) return undefined
+  try {
+    return splitArnParts(value).accountId
+  } catch (_err) {
+    return undefined
+  }
+}
+
+function normalizeStsAssumedRoleArn(value: string): string {
+  if (!value.startsWith('arn:')) return value
+  let parts: ReturnType<typeof splitArnParts>
+  try {
+    parts = splitArnParts(value)
+  } catch (_err) {
+    return value
+  }
+  const resource = parts.resource ?? ''
+  if (parts.service !== 'sts' || !resource.startsWith('assumed-role/')) return value
+  const assumedRoleParts = resource.slice('assumed-role/'.length).split('/')
+  if (assumedRoleParts.length < 2) return value
+  const rolePathAndName = assumedRoleParts.slice(0, -1).join('/')
+  return `arn:${parts.partition}:iam::${parts.accountId}:role/${rolePathAndName}`
+}


### PR DESCRIPTION
## Summary
- add Principal/NotPrincipal support to Permission and PermissionSet algebra
- add opt-in principal-aware policy statement conversion while preserving existing default behavior
- add principal constraint helpers and thorough data-driven tests for includes, union, intersection, subtraction, conversion, and policy output
