### PR TITLE
fix: deduplicate resolved session principals in whoCan

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@cloud-copilot/iam-expand": "^0.11.29",
         "@cloud-copilot/iam-policy": "^0.1.89",
         "@cloud-copilot/iam-shrink": "^0.1.21",
-        "@cloud-copilot/iam-simulate": "^0.1.149",
+        "@cloud-copilot/iam-simulate": "^0.1.151",
         "@cloud-copilot/iam-utils": "^0.1.63",
         "@cloud-copilot/job": "^0.1.0",
         "@cloud-copilot/log": "^0.1.39",
@@ -88,118 +88,30 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@aws-crypto/crc32": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
-      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/crc32c": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
-      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-crypto/sha1-browser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
-      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/supports-web-crypto": "^5.2.0",
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-js": "^5.2.0",
-        "@aws-crypto/supports-web-crypto": "^5.2.0",
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-crypto/util": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
     "node_modules/@aws-sdk/body-checksum-browser": {
-      "version": "3.972.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/body-checksum-browser/-/body-checksum-browser-3.972.19.tgz",
-      "integrity": "sha512-UNjwofGR4QqWFhcMqb+AvAKZfRIpSemlmHLviW+UD1Y9chL6/4O3gfKeyJJwW8ck1BHL6GCeF8zpvpKxIkgjZw==",
+      "version": "3.972.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/body-checksum-browser/-/body-checksum-browser-3.972.21.tgz",
+      "integrity": "sha512-ZbbH/y+kcR1dNFBxlvP9aacY3qGB57zIJM+0KrCTU7oMtLmBb8BZyPWReqeGZTEdAhUi+JLwIQuVmUMZx+PjPQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/sha256-tree-hash": "^3.972.17",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/sha256-tree-hash": "^3.972.19",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/body-checksum-node": {
-      "version": "3.972.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/body-checksum-node/-/body-checksum-node-3.972.19.tgz",
-      "integrity": "sha512-YR8HYJlVfv7Tw0c58/d8NdEdeo8ORDTBdid7SRoxMyu7Db/bq8nyY1B8TI5VQDE5P6orzzYz55Gt8aOlVXgnLA==",
+      "version": "3.972.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/body-checksum-node/-/body-checksum-node-3.972.21.tgz",
+      "integrity": "sha512-KDgGaui3ig9QL5ArnoMcvETD5Uhr2QisCUGQk/0KnlQqFR9afiqO2onkDX1LyXvBLKuNHEFX3ExT6aN7RPwIQQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/chunked-stream-reader-node": "^3.972.8",
-        "@aws-sdk/sha256-tree-hash": "^3.972.17",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/sha256-tree-hash": "^3.972.19",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -207,18 +119,15 @@
       }
     },
     "node_modules/@aws-sdk/checksums": {
-      "version": "3.1000.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.8.tgz",
-      "integrity": "sha512-v0U9S7gBIme3OTgt1LdbAF4RpvavCc+4GK1+1xqAcqtbrHsEhjQo6R45LKcjhs/+WrRJij1Y0Gztw7QPAIeUfA==",
+      "version": "3.1000.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.10.tgz",
+      "integrity": "sha512-OUNjNcyA8Ai2OdlRUxW5jHUf6XJmqqZk3UddL+mDiUCtXrVqdmIHHkdDFWBlBRjhore/3ZBMgRXgcS0ggtvD0Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@aws-crypto/crc32c": "5.2.0",
-        "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -238,20 +147,18 @@
       }
     },
     "node_modules/@aws-sdk/client-account": {
-      "version": "3.1075.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-account/-/client-account-3.1075.0.tgz",
-      "integrity": "sha512-Trnon9sr20iZvFoB6pKgZEx6XgYlEKlz6o68rs5KSom1UslEqw8JSmkrtkWJvpgL2qX5NDEAYAVCdbCkzRb1+A==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-account/-/client-account-3.1077.0.tgz",
+      "integrity": "sha512-+Psm/yfEz7vSV/M+OsGqDx0T1ESZsvZlEEQSCbo5bYir8bhaIO8AwFGuWoiFSSMMYKE6xel5ALTy+3s6exNLQw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-node": "^3.972.58",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -259,21 +166,19 @@
       }
     },
     "node_modules/@aws-sdk/client-api-gateway": {
-      "version": "3.1075.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-api-gateway/-/client-api-gateway-3.1075.0.tgz",
-      "integrity": "sha512-XlAJLAX0ufEmZqUFCtyy+BmQ18CAnCnT4AuCWFzF7yzLHdirY9HZiovHebK/VoYfYmGag+xBWTnOQHydIQCxuA==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-api-gateway/-/client-api-gateway-3.1077.0.tgz",
+      "integrity": "sha512-jn/5trn7IS5CuT7YBqxIjL0NxL76P4mtUWTtfe7tv6Vw+PL9Bw29Y1Gmlvv9qv5+yNgvEZwA45L6PzmI4a2pAA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-node": "^3.972.58",
-        "@aws-sdk/middleware-sdk-api-gateway": "^3.972.18",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/middleware-sdk-api-gateway": "^3.972.20",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -281,20 +186,18 @@
       }
     },
     "node_modules/@aws-sdk/client-backup": {
-      "version": "3.1075.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-backup/-/client-backup-3.1075.0.tgz",
-      "integrity": "sha512-r55en9JTf8KSFEvc4gnNHQVFpQt15V751cCIdWSKjQDKduvaCMJKIu8bYHymEmJiqQZdTJ5E/TEq15zpMl08yw==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-backup/-/client-backup-3.1077.0.tgz",
+      "integrity": "sha512-AVU3uPdl/sH8Bek1WTqHVkcw8+oHwnPiluJvjfgiYvW9qQhitXd8n8CV9VPRws+QmRlwF9IQIqD/UkxUQJbFOQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-node": "^3.972.58",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -302,20 +205,18 @@
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.1075.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.1075.0.tgz",
-      "integrity": "sha512-typFcdyFwIPt86QPKsO7xwcsYoEmNcDpoNqn0tqa4+Lss7niNKQzPe/765XNgAHO3I1ixiT1OKv8KD6M+CKw2w==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.1077.0.tgz",
+      "integrity": "sha512-itDVNVmdSpH5nhwKwZTiqYEqYI0jL01dHoCIo/NVu6rzHAfKUFgXrZpzvF/79R9o8dyUsC4eSUYY21yIKX785w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-node": "^3.972.58",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -323,20 +224,18 @@
       }
     },
     "node_modules/@aws-sdk/client-config-service": {
-      "version": "3.1075.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-config-service/-/client-config-service-3.1075.0.tgz",
-      "integrity": "sha512-Yd7VPZIorkDbG6742YOnqYeTOKyawuVK6DB9crKghYj0Ve1SpYgWNnhX8WCuNKBIQIZ0Hqr1Znr53MtcQ1cvqw==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-config-service/-/client-config-service-3.1077.0.tgz",
+      "integrity": "sha512-ymsuFekKu/g5I+nwTsLFAsRv4y/4WcXGUo50hxNG0ZPg4LGXbCcfkneYGNR+VYB2g5h7CzBCQCwUgjT4SeXqdw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-node": "^3.972.58",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -344,22 +243,20 @@
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.1075.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1075.0.tgz",
-      "integrity": "sha512-3KlTXh6U2nDqL+epT1XdxnszLtCEAvoeO7phI4UGiQeKMiibcyBsJvSlyEj1tBoNOsbdcmp1QLM8za415sDzzQ==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1077.0.tgz",
+      "integrity": "sha512-ekrGdih4Yklq5mgDwLatRuJtiMm32ERjhoCpH59qGzvq0DsWN1NopTjdwwSNxdM6WfkXBxrTDwZ5sjXm4MwWRA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-node": "^3.972.58",
-        "@aws-sdk/dynamodb-codec": "^3.973.23",
-        "@aws-sdk/middleware-endpoint-discovery": "^3.972.19",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/dynamodb-codec": "^3.973.25",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.21",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -367,20 +264,18 @@
       }
     },
     "node_modules/@aws-sdk/client-dynamodb-streams": {
-      "version": "3.1075.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb-streams/-/client-dynamodb-streams-3.1075.0.tgz",
-      "integrity": "sha512-rMElU7VnMDFhMa3nWnlskCVkI3j2I/r7JAimLvNdtB0d+ilhKxh1DeqkALnry3opzOLbAQiJGpl8D7C0TCJktQ==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb-streams/-/client-dynamodb-streams-3.1077.0.tgz",
+      "integrity": "sha512-aKBvHn4l1MWNpXpFYkBtq0Zv5Hz7uuiNzZi5AQya/4TTouxipJLpnODnx4yTkslIwuw3WALzOXXIALBSjAaiSg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-node": "^3.972.58",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -388,21 +283,19 @@
       }
     },
     "node_modules/@aws-sdk/client-ec2": {
-      "version": "3.1075.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.1075.0.tgz",
-      "integrity": "sha512-mrj3G83NkalaYNK6T2vDnoQAfHBY7drzoaDfuTmQeXAfSs9+ucddfJLLV95HT3fdYMfJEKf4Xul2dgyb2t3UuA==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.1077.0.tgz",
+      "integrity": "sha512-7q5kJbxMvCVFz0ZGabG+FY+rFosXb2p2CHH0a7S+PWVTM9FfKKYfr587N+gGSshhaxt4fS47X0YY28ccGDtpdA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-node": "^3.972.58",
-        "@aws-sdk/middleware-sdk-ec2": "^3.972.37",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/middleware-sdk-ec2": "^3.972.39",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -410,20 +303,18 @@
       }
     },
     "node_modules/@aws-sdk/client-ecr": {
-      "version": "3.1075.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecr/-/client-ecr-3.1075.0.tgz",
-      "integrity": "sha512-JY78kY7zgnu0eP5EhGppC71/8d53ulhT7TI5AlBoQgOEcifwnqZGRzaQQhVkkOKNxb3qNZ3uhoJ7ee7D9CUvJw==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecr/-/client-ecr-3.1077.0.tgz",
+      "integrity": "sha512-+vk7zVbLiUaWckFKA834SSiejKLWWNtlG1LP39vqX0mKJ/pHLMjCatL/jNA8vTUGuQe16MZ5ERFehjaBuuePvg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-node": "^3.972.58",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -431,20 +322,18 @@
       }
     },
     "node_modules/@aws-sdk/client-efs": {
-      "version": "3.1075.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-efs/-/client-efs-3.1075.0.tgz",
-      "integrity": "sha512-ut6cDYgz7igHpL5A6tlcSEVOp8IgP301FbCtCyDRSmD+ooNwNpiOcGc1jj9xUwUr6x5nAoAWAB3BUAvFFfPbjA==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-efs/-/client-efs-3.1077.0.tgz",
+      "integrity": "sha512-I3ed3edt2+ItS16kGsnWDUdRPx9tJiVkQ5Di93wXu9SbNCJoW/dJUINfaUA6Rx9A/j7EjL2FPQEAxWgM+QtDAQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-node": "^3.972.58",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -452,21 +341,19 @@
       }
     },
     "node_modules/@aws-sdk/client-eventbridge": {
-      "version": "3.1075.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-eventbridge/-/client-eventbridge-3.1075.0.tgz",
-      "integrity": "sha512-tilM71kC+XU0YKaoWbtvr2yJlOJGplltF98CXbNzyIpRAO5qOM1RKGJCmn7AAV/cz7FpwrnK0TkKYFN5rjpZ8A==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-eventbridge/-/client-eventbridge-3.1077.0.tgz",
+      "integrity": "sha512-oTQXkcFDanUKlwCKUucujR3dpPwGkTsTCHqCfN4+hi7FQ9dz8CIZvWXyKTDtRpkA8TnOsm/fS+bV3sjCBIpioQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-node": "^3.972.58",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.37",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -474,23 +361,21 @@
       }
     },
     "node_modules/@aws-sdk/client-glacier": {
-      "version": "3.1075.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-glacier/-/client-glacier-3.1075.0.tgz",
-      "integrity": "sha512-pvR9itOUzduBAPU5eEER+Q1dGADs8GwFDv5jWrtq0cq06nyk7r05XELcEiTy4zc+q+b0GLmNPoiQDB9lTxxiNA==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-glacier/-/client-glacier-3.1077.0.tgz",
+      "integrity": "sha512-T64YE/1rvn4X617XFhZtUE8FKL53p6rQnZXaY1cptjIxC4/Bxk3uEZW6xE+eA3rNgOFYimDL1a4FjwsJ0ujjCQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/body-checksum-browser": "^3.972.19",
-        "@aws-sdk/body-checksum-node": "^3.972.19",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-node": "^3.972.58",
-        "@aws-sdk/middleware-sdk-glacier": "^3.972.18",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/body-checksum-browser": "^3.972.21",
+        "@aws-sdk/body-checksum-node": "^3.972.21",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/middleware-sdk-glacier": "^3.972.20",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -498,20 +383,18 @@
       }
     },
     "node_modules/@aws-sdk/client-glue": {
-      "version": "3.1075.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-glue/-/client-glue-3.1075.0.tgz",
-      "integrity": "sha512-10849e8XW/iMgvGjo8EIsisFWetzMzgUuDl42Gdu64AtVNfRU0WSEvRxMyzBkaM1xy7czgs7s5d7BvB25RXB4A==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-glue/-/client-glue-3.1077.0.tgz",
+      "integrity": "sha512-v7+iyMNATq2Pgb/ezSh23J1TQeNFJ5htvgCU8QC/vAM8FIamVL7syZiAEsxQJ9YHmFkFrQ6MBHUr9IjqtTmh9w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-node": "^3.972.58",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -519,20 +402,18 @@
       }
     },
     "node_modules/@aws-sdk/client-iam": {
-      "version": "3.1075.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iam/-/client-iam-3.1075.0.tgz",
-      "integrity": "sha512-nuOWtHyBmVrmCqo9k6Bz3oueo9mdEaIahnrETerH2ZoVAPyDAYH2lFNUd/cj84KgcTxW79phrT2SQuS1eY2k3g==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iam/-/client-iam-3.1077.0.tgz",
+      "integrity": "sha512-ksIkG78SFFlG/Mb840SYbblcBatDlmiOlGGNKqMgYpK68F4rftEhGxXGK0spMCuxj4ek1hkBgAjMcwaAmNmUyw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-node": "^3.972.58",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -540,20 +421,18 @@
       }
     },
     "node_modules/@aws-sdk/client-kafka": {
-      "version": "3.1075.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kafka/-/client-kafka-3.1075.0.tgz",
-      "integrity": "sha512-/ZF8CeiwSa6TDeqahbxpmdUfnBip07JhoieuIjl0LS4YN3Vzx9ZZPiO0STgQQH51nHcn9L6umRsaLJoAWmCW0Q==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kafka/-/client-kafka-3.1077.0.tgz",
+      "integrity": "sha512-sQrviTYH+eaTBkbTOJNU5ZXJneJN5/PViSazU4sRGFWL9XsF12by4G795cZqlePBTv8Ms2IH7iiVWkqEcGLN4w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-node": "^3.972.58",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -561,20 +440,18 @@
       }
     },
     "node_modules/@aws-sdk/client-kinesis": {
-      "version": "3.1075.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kinesis/-/client-kinesis-3.1075.0.tgz",
-      "integrity": "sha512-gsnnx2LpHP3bSmu3zE7SXyJuVBHzbll7FmMVwz55ZobQ8hedDI8zS5g31+G6Y0MgLO/FUMpngcO9kXe2OHjPDQ==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kinesis/-/client-kinesis-3.1077.0.tgz",
+      "integrity": "sha512-HNxlkKtolHqbkERC1gycom01VBnYX1x3ypLIDyS3RMiWSqSQZZHI0EJF3Q/q/GmPviH7V59FVzPZHsbbTZfKKQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-node": "^3.972.58",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -582,20 +459,18 @@
       }
     },
     "node_modules/@aws-sdk/client-kms": {
-      "version": "3.1075.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.1075.0.tgz",
-      "integrity": "sha512-Y++vxbiNFUWBD0E8RHau6yhx0xSWVTSGoWiKDWN4whA2YbW+p6OVDsLCMGVO/B41gRTSt9sqaLSDMaKY/zI/ww==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.1077.0.tgz",
+      "integrity": "sha512-SRFMsYn+ul64AvuupK6DisT3NM0BU8GbPI4YwrlaV97lcJGQuybfKnZ3O1j9DL7ZrWkJOt0kIodc7Sbfn2mw8Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-node": "^3.972.58",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -603,20 +478,18 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda": {
-      "version": "3.1075.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1075.0.tgz",
-      "integrity": "sha512-S+sy0L7WEouGGys0kJZJ+br0sQGxgWC+0nR/4ySsym/CSg/k+VHXBdD697WJLli+X5a76tFBshx5bjgVKgLg4Q==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1077.0.tgz",
+      "integrity": "sha512-Cxa/pnBjeziU1owvx/ERPM1iaZ4wXvwoLjX86dekCfCWtQQkGwunPnTwtwP/toevQnPi1bJNODv0MjFhca00tQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-node": "^3.972.58",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -624,20 +497,18 @@
       }
     },
     "node_modules/@aws-sdk/client-opensearch": {
-      "version": "3.1075.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-opensearch/-/client-opensearch-3.1075.0.tgz",
-      "integrity": "sha512-Nw8Jx3zH5ztDvaAjx2DLZDs4huAdwNhv5DWmAIab9b4zztZjnyDCdfdpaMlJ9+BQaa/AovnGc7YIoDefni+y7w==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-opensearch/-/client-opensearch-3.1077.0.tgz",
+      "integrity": "sha512-zHjGfSRdRGY3Npe+g64fiTE1040G2Rf471giK9p1Z8YAlnyfWXFbLFCrGcVjiPsaTQAlacVZVBnDDU93uxyUYQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-node": "^3.972.58",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -645,20 +516,18 @@
       }
     },
     "node_modules/@aws-sdk/client-organizations": {
-      "version": "3.1075.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-organizations/-/client-organizations-3.1075.0.tgz",
-      "integrity": "sha512-mfrlu3pZF4n1uQrKUSIcY4dV6wn7y1gyxBxAXLYGAjii1BoChDGtHbmV5Lwh3SIlVY8LJRC7SLofZN8kdms9yA==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-organizations/-/client-organizations-3.1077.0.tgz",
+      "integrity": "sha512-CRdVa/lVJQeyVm0Q/2dB0BiCUbI4Rp3LuYMvc8jPB7RiLQrSu1lRHHDYzR6FlQAod4uneHszbr71aVUSlSKk7w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-node": "^3.972.58",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -666,20 +535,18 @@
       }
     },
     "node_modules/@aws-sdk/client-ram": {
-      "version": "3.1075.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ram/-/client-ram-3.1075.0.tgz",
-      "integrity": "sha512-zIJ7XrnZQnRO4BSKSlpOn+HYx5HNyQcd34CxAEtvPPNU733UNsGIDcLGQ5Kw7QZIu9nS003zF5qAG5manhJp3g==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ram/-/client-ram-3.1077.0.tgz",
+      "integrity": "sha512-GEy07ANJZUxa/sLCsyP+TrODmIVZ1XqPH55c7Y7gxrTiADk0bJ/GY3fgI8LRMK9qfMg7555id45pHkj6gTTHQw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-node": "^3.972.58",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -687,24 +554,21 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1075.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1075.0.tgz",
-      "integrity": "sha512-h1A6nIl1YX6Y45enGsTK7ef3ZrOnBiQJ1qF5R2K/nMWfsu6A9mc2Y5T66nxerABzyjjyyvign3MrzafnFoQKmA==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1077.0.tgz",
+      "integrity": "sha512-yWK6jOMrMUgGarXlrQaAopWXva20NaOqTPApuE68SzsBFQ57fQ5E13BKUPLwtPgymk+8L6vG/O4h7Q30IBYr2w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha1-browser": "5.2.0",
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-node": "^3.972.58",
-        "@aws-sdk/middleware-flexible-checksums": "^3.974.33",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.54",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/checksums": "^3.1000.10",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.56",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.37",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -712,22 +576,20 @@
       }
     },
     "node_modules/@aws-sdk/client-s3-control": {
-      "version": "3.1075.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3-control/-/client-s3-control-3.1075.0.tgz",
-      "integrity": "sha512-yWx3XxFG/M+frYZp6i7liukOyXXC3tOJkWP6d6ew+RIKoxO+Yhk1Da/afZPua7Y5zENQw7fH0MT2XWI7yraPzw==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3-control/-/client-s3-control-3.1077.0.tgz",
+      "integrity": "sha512-HKBvmZdbP/jC2wp2ExGU/TCP0x+VUWdoITouzFLrJr/QuqO9njeS5XjW9lCjechzjQAkHAINAfkIqXlD1k6yew==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-node": "^3.972.58",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.54",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/middleware-apply-body-checksum": "^4.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.56",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/middleware-apply-body-checksum": "^4.5.4",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -735,20 +597,18 @@
       }
     },
     "node_modules/@aws-sdk/client-s3outposts": {
-      "version": "3.1075.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3outposts/-/client-s3outposts-3.1075.0.tgz",
-      "integrity": "sha512-tvgWrYMCP38LX6CwbVmGvddeKEIBbojt8iNUyuKk2P2T806FgqQPTBpXMKhPsOVC0Dp6/+gxqZsh+q11KvvkEw==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3outposts/-/client-s3outposts-3.1077.0.tgz",
+      "integrity": "sha512-56UQYL4wOSnbVLCyu0TZi5SDQLAIZKFSPKEzEm7Cg9ZirdaC821WW7JF93n/z+1KgSnCG6dYrO52DpwVnlkt2A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-node": "^3.972.58",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -756,20 +616,18 @@
       }
     },
     "node_modules/@aws-sdk/client-s3tables": {
-      "version": "3.1075.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3tables/-/client-s3tables-3.1075.0.tgz",
-      "integrity": "sha512-C8q8CbDtDgC4bt3eQhK6wbnfjNgkg+Icfalq/Pvz2BsmoWqQLa+zlNNfN+EgKuA8bjGLzzE2sdPA/lgCFpmZrA==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3tables/-/client-s3tables-3.1077.0.tgz",
+      "integrity": "sha512-3TeJ2galCU3i/vorEMnHgk+LVXi2NVFRFZCXgBWx9MVZL6jodfTBI5ZfF8ZVh6VqntPzkEqnbnJ9EZnDQfw9uQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-node": "^3.972.58",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -777,20 +635,18 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1075.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1075.0.tgz",
-      "integrity": "sha512-5cLjSmrgzohO2q4gMrb7oHq58W+gR/qul7yHSRZ1fZv7aYtONvq23dKr+E7i0KBid4zkjGpjw8VJ7fNdQi9YUQ==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1077.0.tgz",
+      "integrity": "sha512-8fYAVaaljFNHZO8EPVRsJL42i8Ot7Eexa76BbJiHWt/iSuugUDrjlvd82f5MvKwJLQPok4O1DHHQc51Ahbeg9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-node": "^3.972.58",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -798,20 +654,18 @@
       }
     },
     "node_modules/@aws-sdk/client-sns": {
-      "version": "3.1075.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.1075.0.tgz",
-      "integrity": "sha512-z+GHXov9fkyAkBDZontInAPWGoUnBhMrPFuSX4FGZaCxhVo9UIStcYjpSBy1+aZN1yB7NRaGQYI0WfEAPv399w==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.1077.0.tgz",
+      "integrity": "sha512-ut4R3R6SAWKlmzv6+62tBjq/R7oRv7mb22gHsXunhHSvM8TRENDrHHS9JaKIk1j29Yf91O0PHrB4EsCAY1YroA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-node": "^3.972.58",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -819,21 +673,19 @@
       }
     },
     "node_modules/@aws-sdk/client-sqs": {
-      "version": "3.1075.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.1075.0.tgz",
-      "integrity": "sha512-ZHowzLHFTIz482Z98Y8GtszLN7Q1YvC74xxExwr2rbKJeNWTXHVoMVwlq/jv5Kyf0elVAGmoID12Gf6aSdWy0Q==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.1077.0.tgz",
+      "integrity": "sha512-0Va2lVrbM34lFxRmHu8DQKW8lQ5kdZKC4MxgNIvsC7s/FReOtVMzDFqQw/U6HL72NdLe045zhXxu44cTVoivBA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-node": "^3.972.58",
-        "@aws-sdk/middleware-sdk-sqs": "^3.972.31",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/middleware-sdk-sqs": "^3.972.33",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -841,20 +693,18 @@
       }
     },
     "node_modules/@aws-sdk/client-sso-admin": {
-      "version": "3.1075.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-admin/-/client-sso-admin-3.1075.0.tgz",
-      "integrity": "sha512-HO5XjUnN+C9KbRPhf+2mmgNocAj2rksyhteD3TIcvObjEQqvNsiF1nSGRJE7MV5IuljZXq9ur92qcDyMKfRD3w==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-admin/-/client-sso-admin-3.1077.0.tgz",
+      "integrity": "sha512-BO7ptR9O1Y2RaVzoFT25QKmTUh21kesLBmiu5IMzfBlVZGMetj01vvEFZknJNPCTXfLZUjXcF7ZBhiezLfUrMw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-node": "^3.972.58",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -862,21 +712,19 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.1075.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.1075.0.tgz",
-      "integrity": "sha512-R3cIPHb+Y25nbnIJp1VVQCKA+ajZ06vprGFaRG/nu9ypfo5HRsZj+3We1H1nmIyqzgGMdkoMqMS2XujxuCJXaA==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.1077.0.tgz",
+      "integrity": "sha512-BOLZhSY64I5agdvWx5FSSRQQhOP3OIJ40eDK4tYZLnEE6ghQqQRPhgUItd1JaiK+TQ0Gt9hjU9SkYHFxEU69XQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-node": "^3.972.58",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.37",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -884,17 +732,17 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.23",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.23.tgz",
-      "integrity": "sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==",
+      "version": "3.974.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.25.tgz",
+      "integrity": "sha512-fJFkx6u6wCqGMV/v6EAxiwa2UzEukbvr1hNPv4MrD3yj4IFz011jZg42/eSTOP/u5kJ0tlILqEjCWtT8GiKZvA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.13",
-        "@aws-sdk/xml-builder": "^3.972.31",
+        "@aws-sdk/types": "^3.973.14",
+        "@aws-sdk/xml-builder": "^3.972.32",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.6",
-        "@smithy/signature-v4": "^5.4.6",
-        "@smithy/types": "^4.14.3",
+        "@smithy/core": "^3.28.0",
+        "@smithy/signature-v4": "^5.6.0",
+        "@smithy/types": "^4.15.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -903,15 +751,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.972.48",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.972.48.tgz",
-      "integrity": "sha512-dTSY4wCPx87Gd1peDcTop1li61f6KLAs3LSlq/omnCxpIOvMDpAQjylJ7ZDaZk6KA88+oZ0k/XuVSou1YuWI/w==",
+      "version": "3.972.50",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.972.50.tgz",
+      "integrity": "sha512-pAYnOzaCl6EWTuGLk5+YsZ7Dyec7SNJBLzyJem1OXS7sfEquMguox/q9rv/sYwxi1CkPrw76YFcFD5K8o/DjGw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/nested-clients": "^3.997.23",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/nested-clients": "^3.997.25",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -919,15 +767,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.49",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.49.tgz",
-      "integrity": "sha512-liB3yQNHCM9k/gu/w36XHMKPluT7HTlnGUhRbBGSISDQkcr/Sy1zsZabiuvQj8WG5yW573u9RehrBvvnIQ9OEQ==",
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.51.tgz",
+      "integrity": "sha512-Xo+/zf5k5pZdo53X8aVXN4MJGfU/M1P7yMM/GbNY/x9fyRZGEzjhKqW38GA0FSQQ9TYKs+bfPyz5ja4bi6pjTQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -935,17 +783,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.51",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.51.tgz",
-      "integrity": "sha512-XET0H2oofciJ5lMRWNIvRjAP7Q3wv2XT+JtJJEdhPWUMwe3TvQ9qcxonpu7vXmNngncvFpi4E2It+Tamas/naA==",
+      "version": "3.972.53",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.53.tgz",
+      "integrity": "sha512-7E9oFUcf9YWe+ttGiWhe/cCSI+pswwelzgQMoKXgPJi1AIfS27TK6et5ZULqEqHu30zbN+jh1RqlwcXqY/aXyg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -953,23 +801,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.56",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.56.tgz",
-      "integrity": "sha512-IAmc61hbgQiHht9U3x0tnRwz0lzdwOwD/i9voRgdJrKamF+JtmrBOsW9GwB7mfFonNWOWL4qARWYrF8veEMe3w==",
+      "version": "3.972.58",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.58.tgz",
+      "integrity": "sha512-MPr0hD8pyDGfF3dWXvFOILhcKTB9ptqJOJK9JEuDQzpc2HgKisY16eR7IrKUXxSbz8LZj+LHz/CS8Y5G1ai7yw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-env": "^3.972.49",
-        "@aws-sdk/credential-provider-http": "^3.972.51",
-        "@aws-sdk/credential-provider-login": "^3.972.55",
-        "@aws-sdk/credential-provider-process": "^3.972.49",
-        "@aws-sdk/credential-provider-sso": "^3.972.55",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.55",
-        "@aws-sdk/nested-clients": "^3.997.23",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/credential-provider-imds": "^4.3.7",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-env": "^3.972.51",
+        "@aws-sdk/credential-provider-http": "^3.972.53",
+        "@aws-sdk/credential-provider-login": "^3.972.57",
+        "@aws-sdk/credential-provider-process": "^3.972.51",
+        "@aws-sdk/credential-provider-sso": "^3.972.57",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.57",
+        "@aws-sdk/nested-clients": "^3.997.25",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/credential-provider-imds": "^4.4.4",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -977,16 +825,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.55",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.55.tgz",
-      "integrity": "sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA==",
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.57.tgz",
+      "integrity": "sha512-kPWc/SCrl9agKeywxKwPEoQHanWag0LcNQrcZpEQpjNifkxq6tQENhgrrS9al317CF6yytyihlX+FhPHlk0QjA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/nested-clients": "^3.997.23",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/nested-clients": "^3.997.25",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -994,21 +842,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.58",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.58.tgz",
-      "integrity": "sha512-OyCLVmSI7pZO8hxwNVX6pXhTVlJqRBTp+ijdEfJSUj0RyjHnF602OfAarOzGq6wkGodeFkYBt8MmJ6A6ycRgWw==",
+      "version": "3.972.60",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.60.tgz",
+      "integrity": "sha512-hE2hIBJQjCDRx8TbSqpVQ+/o2mIrJZQZbQ3LlwE2bJf7z47x5GmhcvGwZPqJH7Oq//SzTXEBGSZ4qSpK3yPbhw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.49",
-        "@aws-sdk/credential-provider-http": "^3.972.51",
-        "@aws-sdk/credential-provider-ini": "^3.972.56",
-        "@aws-sdk/credential-provider-process": "^3.972.49",
-        "@aws-sdk/credential-provider-sso": "^3.972.55",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.55",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/credential-provider-imds": "^4.3.7",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/credential-provider-env": "^3.972.51",
+        "@aws-sdk/credential-provider-http": "^3.972.53",
+        "@aws-sdk/credential-provider-ini": "^3.972.58",
+        "@aws-sdk/credential-provider-process": "^3.972.51",
+        "@aws-sdk/credential-provider-sso": "^3.972.57",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.57",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/credential-provider-imds": "^4.4.4",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1016,15 +864,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.49",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.49.tgz",
-      "integrity": "sha512-C8h36lBuC/RnBSsjlO+dn6xZm3KbAl5vpJaVPAfQnMmz2/OISmKOc8XZcqMQgO2ADwBYNRMM6Kf3vz9G/TulMQ==",
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.51.tgz",
+      "integrity": "sha512-081dD2RlnmY+G05v6E73KfACvDjPjnttrLjGHE2SSglbID25UcuijbWpL4g+XR5T2Kl4oIJoVBXi64s+2f009Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1032,17 +880,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.55",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.55.tgz",
-      "integrity": "sha512-1FkOz74Ea5QGS9jtIoXp55T/IkSS3spv+nLTT07fRY/+T5xmEOqaYBVIaEmX4zTNvbV6g2lrtlaVKWEoNyJt3w==",
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.57.tgz",
+      "integrity": "sha512-dC7ZyX3EHKHLOeVUEDzzGvk0L1s6N06YDrau7P0rGXL/j1cO+DzN2w1x9vcEh7zljVCR3019f5mi1Th+GGTURw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/nested-clients": "^3.997.23",
-        "@aws-sdk/token-providers": "3.1074.0",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/nested-clients": "^3.997.25",
+        "@aws-sdk/token-providers": "3.1077.0",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1050,16 +898,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.55",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.55.tgz",
-      "integrity": "sha512-g2BoECD1q01kTPByi56+VLVvdWDzMkKIcr77qixpqH0okw2t0U5CoPv+6S8v/D1Y2Wa6QKKtn6XAtDzP+Kfpvg==",
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.57.tgz",
+      "integrity": "sha512-HtWM3FV2o7NJFJSUqFLBlxmV9RxQRHpzCvQaP1n1Qo4CxQSvwpJ8ERWHiLqXMFDgDXyELt+EZNFcpG6XQRcJbQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/nested-clients": "^3.997.23",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/nested-clients": "^3.997.25",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1067,27 +915,27 @@
       }
     },
     "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.1075.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.1075.0.tgz",
-      "integrity": "sha512-2HoJ1IxwdzEryyUmZvl6dVKfgWBnS6NzSDl5hOqmbHns5Cy+wCQLDFU+HGVi+kTGZgSyMZIa0rH7fQvNf7v9jQ==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.1077.0.tgz",
+      "integrity": "sha512-yUPM6RKM9BQkWVaW6E8UV0DOUT/YyOERhoC2tpSzbb5riekB16t66O0T5FyywFaeaOeNrx9/DhV9My93mahAog==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.1075.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-cognito-identity": "^3.972.48",
-        "@aws-sdk/credential-provider-env": "^3.972.49",
-        "@aws-sdk/credential-provider-http": "^3.972.51",
-        "@aws-sdk/credential-provider-ini": "^3.972.56",
-        "@aws-sdk/credential-provider-login": "^3.972.55",
-        "@aws-sdk/credential-provider-node": "^3.972.58",
-        "@aws-sdk/credential-provider-process": "^3.972.49",
-        "@aws-sdk/credential-provider-sso": "^3.972.55",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.55",
-        "@aws-sdk/nested-clients": "^3.997.23",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/credential-provider-imds": "^4.3.7",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/client-cognito-identity": "3.1077.0",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-cognito-identity": "^3.972.50",
+        "@aws-sdk/credential-provider-env": "^3.972.51",
+        "@aws-sdk/credential-provider-http": "^3.972.53",
+        "@aws-sdk/credential-provider-ini": "^3.972.58",
+        "@aws-sdk/credential-provider-login": "^3.972.57",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/credential-provider-process": "^3.972.51",
+        "@aws-sdk/credential-provider-sso": "^3.972.57",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.57",
+        "@aws-sdk/nested-clients": "^3.997.25",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/credential-provider-imds": "^4.4.4",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1095,14 +943,14 @@
       }
     },
     "node_modules/@aws-sdk/dynamodb-codec": {
-      "version": "3.973.23",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.23.tgz",
-      "integrity": "sha512-GFfrjNXw+QteWbum8jD22G3T0FD/XiJEGp6r1CoqndMc6pxyQFoQ8nqTuNn1rbqYwqv4iCTl7GYoB9H17REKzw==",
+      "version": "3.973.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.25.tgz",
+      "integrity": "sha512-4JzlsPxm8e/haqlzGEOmj/k0dVi65tkcLM+jLBkEhjG2+858hsXYyP/seBuq850FZ+XY1v0cp56C8m4pKu/Mrg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.23",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@smithy/core": "^3.28.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1123,28 +971,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.972.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.19.tgz",
-      "integrity": "sha512-FMgyzUq3Jh+ONRYxryBRNdBd+FUX8PwRl07ccQknNdoms6KCeAEusCkl6whqpDrPQ6OH0ddeSifKyqYSs2DLIw==",
+      "version": "3.972.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.21.tgz",
+      "integrity": "sha512-MCtOtk3rGtdSz4ie6JL/8vgAMlQFf32t+SqkxqQ/3DKq390cJCQ/oUA7EMLnbHBjOo8Hq1Nmazu7x8ItpArFgg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/endpoint-cache": "^3.972.8",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.974.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.33.tgz",
-      "integrity": "sha512-qMgQSPemQq2/eW/e/0+SpY4kYR5L7dUgBiVdEc5bd+ztHNv07ZMYiI+sTiir3TgKndFfglSw/VFi7oZJ6bZ63g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/checksums": "^3.1000.8",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1152,14 +987,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-api-gateway": {
-      "version": "3.972.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-api-gateway/-/middleware-sdk-api-gateway-3.972.18.tgz",
-      "integrity": "sha512-3xZO1L3f+OshQ+ChcyCQtwZ2eeK7V4xqAxZ3cBDVgyEd8HTnIol9t4UNB5YoCaXOtYWduCtyFDBzKT0tSEAjGQ==",
+      "version": "3.972.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-api-gateway/-/middleware-sdk-api-gateway-3.972.20.tgz",
+      "integrity": "sha512-pEFdxG9U791SDW9etJV1Wuc+utBLG2TitH/fyyoX9YiRh4XKfU6LMMgaoyze7NSjelAjH9Gw1QltXeGqUPEVvQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1167,16 +1002,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-ec2": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.972.37.tgz",
-      "integrity": "sha512-Z8ogjHT2C7YnMb83PhsAKmuySs+UMC6SBKXbtJT5y0mV5vvqm9UmMAiAEP+06hBFt7ta/nYHJvFBP3wjO3+YBQ==",
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.972.39.tgz",
+      "integrity": "sha512-v7BUyFWuOrz6qFTnLF3JU+m4FA3B2sCeH5ZoVuJGYAJrQlp2XcxhfkKgvptwWDL8k4sQ5Yw2ezZsrXBeevcfhw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/signature-v4": "^5.4.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/signature-v4": "^5.6.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1184,14 +1019,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-glacier": {
-      "version": "3.972.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-glacier/-/middleware-sdk-glacier-3.972.18.tgz",
-      "integrity": "sha512-vmyilZwe4TWgWHpHw+aB7lOBJza6DeJpZUDWo27FGQHpWC/0PjyulZN4l28/tdhP7+LgVoM+tkwM+8oLln+aPQ==",
+      "version": "3.972.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-glacier/-/middleware-sdk-glacier-3.972.20.tgz",
+      "integrity": "sha512-nBukYwcf4sVNRjOjwtc7UYkQqWuy3i+oQgrvT8qT6cMYMZ2Llo8ubsUzpHcEpHxRzu33EwHkT6As5Tmv2bX3QA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1199,16 +1034,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.54",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.54.tgz",
-      "integrity": "sha512-GDfDQ0gwLFRKN9gWIKcmVrHJ3e7XagnY7N1LLzMVNgnOnuY7f/ALgmy3CuBjosWD95T/Z6e+gs1IeWmLPkyLKQ==",
+      "version": "3.972.56",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.56.tgz",
+      "integrity": "sha512-VFLd7bT8ef48H2n2iDrY/w9EPpXLmC0v4NEriXy2vuTgEP/FrKqrcwi7eobhcOrdO37uLbMt5AWZlY55R2/xqg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.37",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1216,14 +1051,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sqs": {
-      "version": "3.972.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.972.31.tgz",
-      "integrity": "sha512-56ifsBmK9bLn5EE/t6c0nmjOB1BO8cJDLkA1VOlsN1GR85ROqnaCwVDspqcwsLaBDgPlwyYNedoDIoT3t6Ho1A==",
+      "version": "3.972.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.972.33.tgz",
+      "integrity": "sha512-yur6Whcp2Br6w+AwOpOmeuglu6nArNUy7F0eQyuJ+HV8VMVPRE2av81vK7hLLw1kF/ww5xnnNuyAvtWnSr7mEw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1231,20 +1066,18 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.23",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.23.tgz",
-      "integrity": "sha512-gO93ZPsI2bxeFZD42f1/qjDw6FAZkNZcKRO94LIiT03fzOmcJ9e/tunxjVjA1Rl69ClmVJzz8H3G9CdKef10PA==",
+      "version": "3.997.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.25.tgz",
+      "integrity": "sha512-VpRQ3wR6l+fwRHV5veJL2ehtyQFrGyH/2CJG9DVtb8H3xyqqnZWSTSrq/CJJ7DvDlDgrPRiW2SkYA8pN6VWCFQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.37",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1252,13 +1085,13 @@
       }
     },
     "node_modules/@aws-sdk/sha256-tree-hash": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/sha256-tree-hash/-/sha256-tree-hash-3.972.17.tgz",
-      "integrity": "sha512-EgriHKVinYPV6hm5jepRIABSkGbe2lKVAMDQZTPahTQ6ggtg3pyex86ZXZJu0J9jThEFZEIKP//iaCbShCm8qw==",
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/sha256-tree-hash/-/sha256-tree-hash-3.972.19.tgz",
+      "integrity": "sha512-EZHGeOw630K+e3xmDnrXUjCAzsOIDk0irmrwql45ipfXrcj6/hbk2YF/e/3NYXqkCMEjD/C8bnYthhxXa8ZYFA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1266,14 +1099,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz",
-      "integrity": "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==",
+      "version": "3.996.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.37.tgz",
+      "integrity": "sha512-u8qd064XsHzM0Mk+yH4IPKn/ZC9rdniEKs+neBHNlsPZirw3rcLvmrH4ImoKC4yF7A0I/MbcC3dseARnJLiAhg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/signature-v4": "^5.4.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/signature-v4": "^5.6.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1281,16 +1114,16 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1074.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1074.0.tgz",
-      "integrity": "sha512-pv80IzgGW4RnXWtft692chZOM9i6PhebVsLCcnaM4dBEPZva2fE6FXAHs76G7Rc7s3yGyX/68G0nZMrUy+Vmpg==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1077.0.tgz",
+      "integrity": "sha512-sRUkfZ3fpOco95jZHsQUQiXvuIVLvCmWVclFg6dRFDyfsYs6Pdr/NuZ2+yJxeHN+6WAfDh2aZ8nlZntnvuhZUQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/nested-clients": "^3.997.23",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/nested-clients": "^3.997.25",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1298,24 +1131,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.13.tgz",
-      "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.14.tgz",
+      "integrity": "sha512-vH4pEu9YBEwr67yT+GVcmKX0GzfIrIYUn+MF5vXg9OspouVnAekuyVyawFvZHEK7WlcwVDwNrqI3ZBDUAiyu9A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.965.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.8.tgz",
-      "integrity": "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==",
-      "license": "Apache-2.0",
-      "dependencies": {
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1323,12 +1144,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.31.tgz",
-      "integrity": "sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==",
+      "version": "3.972.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.32.tgz",
+      "integrity": "sha512-2loKuOMRFDg1nwdni5AtJ9S5juVbRNPNsPC7tWTfkHyycPwACMhxepspUHi8GhvfNlL2cQo3sPMod1uib+KZ0w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.3",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1433,9 +1254,9 @@
       "license": "MIT"
     },
     "node_modules/@cloud-copilot/iam-collect": {
-      "version": "0.1.199",
-      "resolved": "https://registry.npmjs.org/@cloud-copilot/iam-collect/-/iam-collect-0.1.199.tgz",
-      "integrity": "sha512-ODib6S7nW2smVOPC127dhrHS6ToeaUh1NvAiEbFeu1/ZrjYQcs58xat9PsrsqaUJOzGpTG1yb4ycx7w03k7RaQ==",
+      "version": "0.1.200",
+      "resolved": "https://registry.npmjs.org/@cloud-copilot/iam-collect/-/iam-collect-0.1.200.tgz",
+      "integrity": "sha512-a+M4Fu9O08xSRIEpV84CzWAs9g8X+HE3e59RVHLtMhNJEwyrUtzKKjc9nPjeanRjyYBvkyT/KQJXimXSXHs07A==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@aws-sdk/client-account": "^3.758.0",
@@ -1484,9 +1305,9 @@
       }
     },
     "node_modules/@cloud-copilot/iam-data": {
-      "version": "0.19.202606271",
-      "resolved": "https://registry.npmjs.org/@cloud-copilot/iam-data/-/iam-data-0.19.202606271.tgz",
-      "integrity": "sha512-dfWhO5PkHQWto79hNnBr+AEWLCIM84EocdgYCNW/vRtuZjdMGHhBjnlhscAzL6DzkUJgcCARUaCjqmg1uCYFTQ==",
+      "version": "0.19.202606301",
+      "resolved": "https://registry.npmjs.org/@cloud-copilot/iam-data/-/iam-data-0.19.202606301.tgz",
+      "integrity": "sha512-y2dvc/zfu/CUhWoXOoCzRAywg+pUDVGoLECT9IKoVWXW0brHfV1NCCy6sWgtnNDA5ZBU9KQiYlF4Xfxx+1jBrw==",
       "license": "MIT"
     },
     "node_modules/@cloud-copilot/iam-expand": {
@@ -1527,9 +1348,9 @@
       }
     },
     "node_modules/@cloud-copilot/iam-simulate": {
-      "version": "0.1.150",
-      "resolved": "https://registry.npmjs.org/@cloud-copilot/iam-simulate/-/iam-simulate-0.1.150.tgz",
-      "integrity": "sha512-byngyXo1rq31YR/TVkSymCz2wWRjKvU9nFSQDtAmUCchnkBLvmkucHbV8InZDCcZNMQbexFPn3ioa5/JzTW6OA==",
+      "version": "0.1.151",
+      "resolved": "https://registry.npmjs.org/@cloud-copilot/iam-simulate/-/iam-simulate-0.1.151.tgz",
+      "integrity": "sha512-dJda5AyLqkhXs16tdguuTUHtQyrhFw6kn47gCZXEfONa/kxGtaCvtYrZAFbBnLCO//tYPW5aRgBVeVHC3CKNNA==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@cloud-copilot/iam-data": ">=0.15.202511222 <1.0.0",
@@ -1777,9 +1598,9 @@
       }
     },
     "node_modules/@octokit/request": {
-      "version": "10.0.10",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.10.tgz",
-      "integrity": "sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==",
+      "version": "10.0.11",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.11.tgz",
+      "integrity": "sha512-+s7HUxjfFqOMS9VlIwDffq0MikjSAK0gSpG73W+meAvVAvX4MBrHYTK5Bj3Uot55qFT4gzUtfzE4mGWY4Br8/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2591,12 +2412,11 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.26.0.tgz",
-      "integrity": "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.28.0.tgz",
+      "integrity": "sha512-N/LoLG8pZ1zv5cIWpdF6vmSjtZtXKK9G0OqT5yYCOZU+CzPq1+nYA95VoKJBGWRScs7YbMugZ7lZx8Fj1vdHoA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
         "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
@@ -2605,12 +2425,12 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.2.tgz",
-      "integrity": "sha512-18UMDMyrAbDcpmL1gLUA7ww0fRTcdCrSjSJOi2Sbld+tVjwD/pW+OAwjlScFLR7vvBnhZrIPQ7kVuTf1mnJLug==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.4.tgz",
+      "integrity": "sha512-jT0WrDaM88L5na9FX1xRNywCS3B1n75wPY5Ksasjo0PHUtuI7d8FclksN1BbOSYTiaiKxUDqU23nUymH/V+AaQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.26.0",
+        "@smithy/core": "^3.28.0",
         "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
@@ -2619,12 +2439,12 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.5.2.tgz",
-      "integrity": "sha512-Ei/UK/QMhq0rKaMqGPlOAkE2yS9DZeYmZdk1RAKc3vp3zxgleZHZyBLlZv8yLsxljX4svCRuMTD6u3LLIcU4Bg==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.1.tgz",
+      "integrity": "sha512-fW6l9rWoyk1iyzfuZaERnZLNjB6WIojgGm6Bo9Hpfpy3RUpltjLikNlxTsS/YtxVobcfbCGBuAncREYqT4hvqQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.26.0",
+        "@smithy/core": "^3.28.0",
         "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
@@ -2632,25 +2452,13 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@smithy/middleware-apply-body-checksum": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-apply-body-checksum/-/middleware-apply-body-checksum-4.5.2.tgz",
-      "integrity": "sha512-NoGyX8kQL1RX1F9cgWCUcdFyWVMYpwoRATbtd7xEAVbmcrfwkeP1+Xz+sB76G11po/0PmfJ5Nlgh+73VYvkqvg==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-apply-body-checksum/-/middleware-apply-body-checksum-4.5.4.tgz",
+      "integrity": "sha512-Pzv2oB8aUcwmR9pBurXNeyTjPsmAkGnrBKhthOJmrAboo7m/WivR18T1O/mkHz5pmXX3+3weuIQZduNJlJpuog==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.26.0",
+        "@smithy/core": "^3.28.0",
         "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
@@ -2659,12 +2467,12 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.2.tgz",
-      "integrity": "sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.1.tgz",
+      "integrity": "sha512-m/f15di58P6NtLQ7eVEb5N19NdJWn+4c7zfkFHMT/i3JH7U8UtknpPoy8o2tm2R3OdliYvsvQhZHIfACQDqT+Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.26.0",
+        "@smithy/core": "^3.28.0",
         "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
@@ -2673,12 +2481,12 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.5.2.tgz",
-      "integrity": "sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.0.tgz",
+      "integrity": "sha512-IkPHQdbyoebSwBCuMTzJ/2oIhKVqiZZAZxQYSlpDZqq/WhJUpmdgbHvP7ItddxsPzcDUJeI0V4PNMSNtlZ0aqA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.26.0",
+        "@smithy/core": "^3.28.0",
         "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
@@ -2687,12 +2495,12 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.14.2.tgz",
-      "integrity": "sha512-H3fp0F/IhG8a6qnoWHeGTH1qDPRR9VVZjcxM9NMXPB6nqzaqcoYIX8D4FFI1Ap2siGr+yvYgKqHC76+afBgF1A==",
+      "version": "4.14.4",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.14.4.tgz",
+      "integrity": "sha512-C0yK69+L7DAdTc2iA5LkPYlj1sWz8LciaIMFEgSJ4dKrZx7CVhgU0ss80g0z+CQZd9qlABbLMs7e2naL/O8zzQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.26.0",
+        "@smithy/core": "^3.28.0",
         "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
@@ -2712,43 +2520,17 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@smithy/util-retry": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.5.2.tgz",
-      "integrity": "sha512-iinqHq7WnWWKQUCObyu4YBzXROJO8dHMQrM+pvut92rKgjhcLNHel8QVJNsIswjPLOEJffq6sYjOdq/ndOrIAA==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.5.4.tgz",
+      "integrity": "sha512-3SbMLJJ1n0sNMyEsDu7IUbSlXGBg9PPpkmmHi6qokQQ7jp/sf3kTssqoyohjCZ704WjdXpDEM/xX8Mx+t5tElQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.26.0",
+        "@smithy/core": "^3.28.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@standard-schema/spec": {
@@ -3989,9 +3771,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4156,9 +3938,9 @@
       "license": "MIT"
     },
     "node_modules/fs-extra": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
+      "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5327,9 +5109,9 @@
       "license": "MIT"
     },
     "node_modules/node-abi": {
-      "version": "3.92.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
-      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "version": "3.93.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.93.0.tgz",
+      "integrity": "sha512-Cu6yUpX5Iavugm8BeX7c0wgU9CvOqfd1yM6A1d2q2ZMjym7GjpASv2GdRcTq3Fx+Sb5OgBkEEpw4VnAbY6Y5RA==",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -5383,9 +5165,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.17.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.17.0.tgz",
-      "integrity": "sha512-PurxiZexEHDTE4SSaLI3ZrnbAGiZfeyUcQcxcP5D+hfytNAze/D1IzDuInTn9XVLIbAQUnQuSPXJx02LHjLvQw==",
+      "version": "11.18.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.18.0.tgz",
+      "integrity": "sha512-T67M4L5wNm0cZ7EBLErcEkY1SmzEW/WJ+SADBzsFUY1UdAPfFHXFQtZ6SEXiK0+vzXysCvAsepbMaBTwnrAD+w==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -5464,8 +5246,8 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.8.0",
-        "@npmcli/config": "^10.11.0",
+        "@npmcli/arborist": "^9.9.0",
+        "@npmcli/config": "^10.12.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
@@ -5489,11 +5271,11 @@
         "is-cidr": "^6.0.4",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.10",
-        "libnpmexec": "^10.3.0",
-        "libnpmfund": "^7.0.24",
+        "libnpmdiff": "^8.1.11",
+        "libnpmexec": "^10.3.1",
+        "libnpmfund": "^7.0.25",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.10",
+        "libnpmpack": "^9.1.11",
         "libnpmpublish": "^11.2.0",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
@@ -5509,7 +5291,7 @@
         "npm-install-checks": "^8.0.0",
         "npm-package-arg": "^13.0.2",
         "npm-pick-manifest": "^11.0.3",
-        "npm-profile": "^12.0.1",
+        "npm-profile": "^12.0.2",
         "npm-registry-fetch": "^19.1.1",
         "npm-user-validate": "^4.0.0",
         "p-map": "^7.0.4",
@@ -5518,11 +5300,11 @@
         "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
         "read": "^5.0.1",
-        "semver": "^7.8.4",
+        "semver": "^7.8.5",
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.16",
+        "tar": "^7.5.19",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -5594,7 +5376,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.8.0",
+      "version": "9.9.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5642,7 +5424,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.11.0",
+      "version": "10.12.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5987,7 +5769,7 @@
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "5.0.6",
+      "version": "5.0.7",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6361,12 +6143,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.1.10",
+      "version": "8.1.11",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.8.0",
+        "@npmcli/arborist": "^9.9.0",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -6380,13 +6162,13 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.3.0",
+      "version": "10.3.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
-        "@npmcli/arborist": "^9.8.0",
+        "@npmcli/arborist": "^9.9.0",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -6403,12 +6185,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.24",
+      "version": "7.0.25",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.8.0"
+        "@npmcli/arborist": "^9.9.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -6428,12 +6210,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.1.10",
+      "version": "9.1.11",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.8.0",
+        "@npmcli/arborist": "^9.9.0",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -6802,13 +6584,13 @@
       }
     },
     "node_modules/npm/node_modules/npm-profile": {
-      "version": "12.0.1",
+      "version": "12.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "npm-registry-fetch": "^19.0.0",
-        "proc-log": "^6.0.0"
+        "proc-log": "^6.1.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -7013,7 +6795,7 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.8.4",
+      "version": "7.8.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7138,7 +6920,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.16",
+      "version": "7.5.19",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -7234,7 +7016,7 @@
       }
     },
     "node_modules/npm/node_modules/undici": {
-      "version": "6.26.0",
+      "version": "6.27.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7429,9 +7211,9 @@
       }
     },
     "node_modules/p-map": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
-      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.5.tgz",
+      "integrity": "sha512-e8vJF4XdVkzqqSHguEMz41mQO1wKwxKm5ENrUJQUu9kLDCtn83cxbyHZcszr4QC5zEA7WffRRC4gsTecC7J9oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7624,9 +7406,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "dev": true,
       "funding": [
         {
@@ -7680,9 +7462,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.0.tgz",
-      "integrity": "sha512-LjIqSIC5VYLzs9WedVmJ2ljNAGnU+DteIClbahu4L/DBeWjZ6iT/k1lAYyu9JUh+1xINxWadaPw/Pl63y/agAw==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -9141,16 +8923,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.0.tgz",
-      "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.2.tgz",
+      "integrity": "sha512-6YYPbRXTxx6bRXmOn7XdnQAy5DQNHhDgtjhDHI13oe4pY93kkcdGJWxpGwOm++/Wh0QpQhDrpIoVMrmrsI5AGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.15",
-        "rolldown": "~1.1.2",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.3",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "@cloud-copilot/iam-expand": "^0.11.29",
     "@cloud-copilot/iam-policy": "^0.1.89",
     "@cloud-copilot/iam-shrink": "^0.1.21",
-    "@cloud-copilot/iam-simulate": "^0.1.149",
+    "@cloud-copilot/iam-simulate": "^0.1.151",
     "@cloud-copilot/iam-utils": "^0.1.63",
     "@cloud-copilot/job": "^0.1.0",
     "@cloud-copilot/log": "^0.1.39",

--- a/src/test-datasets/iam-data-1/aws/aws/accounts/200000000002/s3/who-can-account-and-session/metadata.json
+++ b/src/test-datasets/iam-data-1/aws/aws/accounts/200000000002/s3/who-can-account-and-session/metadata.json
@@ -1,0 +1,5 @@
+{
+  "name": "who-can-account-and-session",
+  "region": "us-west-2",
+  "arn": "arn:aws:s3:::who-can-account-and-session"
+}

--- a/src/test-datasets/iam-data-1/aws/aws/accounts/200000000002/s3/who-can-account-and-session/policy.json
+++ b/src/test-datasets/iam-data-1/aws/aws/accounts/200000000002/s3/who-can-account-and-session/policy.json
@@ -1,0 +1,28 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowAccount",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": ["s3:ListBucket"],
+      "Resource": ["arn:aws:s3:::who-can-account-and-session"],
+      "Condition": {
+        "StringEquals": {
+          "aws:PrincipalAccount": "100000000001"
+        }
+      }
+    },
+    {
+      "Sid": "AllowPathlessSession",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+          "arn:aws:sts::100000000001:assumed-role/AWSReservedSSO_AdministratorAccess_0fed56ec5d997fc5/session-abc"
+        ]
+      },
+      "Action": ["s3:ListBucket"],
+      "Resource": ["arn:aws:s3:::who-can-account-and-session"]
+    }
+  ]
+}

--- a/src/test-datasets/iam-data-1/aws/aws/accounts/200000000002/s3/who-can-session-xacct/policy.json
+++ b/src/test-datasets/iam-data-1/aws/aws/accounts/200000000002/s3/who-can-session-xacct/policy.json
@@ -6,7 +6,7 @@
       "Effect": "Allow",
       "Principal": {
         "AWS": [
-          "arn:aws:sts::100000000001:assumed-role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_AdministratorAccess_0fed56ec5d997fc5/session-abc"
+          "arn:aws:sts::100000000001:assumed-role/AWSReservedSSO_AdministratorAccess_0fed56ec5d997fc5/session-abc"
         ]
       },
       "Action": ["s3:ListBucket", "s3:GetObject"],

--- a/src/test-datasets/iam-data-1/aws/aws/indexes/buckets-to-accounts.json
+++ b/src/test-datasets/iam-data-1/aws/aws/indexes/buckets-to-accounts.json
@@ -59,6 +59,10 @@
     "accountId": "200000000002",
     "region": "us-west-2"
   },
+  "who-can-account-and-session": {
+    "accountId": "200000000002",
+    "region": "us-west-2"
+  },
   "eu-example-data-lake": {
     "accountId": "100000000001",
     "region": "us-west-2"

--- a/src/whoCan/WhoCanProcessor.ts
+++ b/src/whoCan/WhoCanProcessor.ts
@@ -922,7 +922,8 @@ export class WhoCanProcessor {
 
     const accountsToCheck = await accountsToCheckBasedOnResourcePolicy(
       resourcePolicy,
-      resourceAccount
+      resourceAccount,
+      collectClient
     )
 
     const principalArnFilter = buildPrincipalArnFilter(resourcePolicy)

--- a/src/whoCan/whoCan.test.ts
+++ b/src/whoCan/whoCan.test.ts
@@ -11,6 +11,10 @@ import {
   type WhoCanResponse
 } from './whoCan.js'
 
+const noPrincipalResolutionClient = {
+  resolvePrincipalArn: async () => undefined
+} as unknown as IamCollectClient
+
 const findResourceTypeForArnTests: {
   only?: boolean
   input: string
@@ -2441,7 +2445,7 @@ const accountsToCheckBasedOnResourcePolicyTests: {
   },
   // --- Session ARN conversion (assumed-role) ---
   {
-    name: 'should convert assumed-role session ARN to role ARN in Principal',
+    name: 'should keep unresolved assumed-role session ARN in Principal',
     resourcePolicy: {
       Version: '2012-10-17',
       Statement: [
@@ -2459,7 +2463,7 @@ const accountsToCheckBasedOnResourcePolicyTests: {
     expected: {
       allAccounts: false,
       specificAccounts: [],
-      specificPrincipals: ['arn:aws:iam::666666666666:role/MyRole'],
+      specificPrincipals: ['arn:aws:sts::666666666666:assumed-role/MyRole/my-session'],
       specificOrganizations: [],
       specificOrganizationalUnits: [],
       checkAnonymous: false,
@@ -2467,7 +2471,7 @@ const accountsToCheckBasedOnResourcePolicyTests: {
     }
   },
   {
-    name: 'should convert assumed-role session ARN with path to role ARN in Principal',
+    name: 'should keep unresolved path-containing assumed-role session ARN in Principal',
     resourcePolicy: {
       Version: '2012-10-17',
       Statement: [
@@ -2485,7 +2489,7 @@ const accountsToCheckBasedOnResourcePolicyTests: {
     expected: {
       allAccounts: false,
       specificAccounts: [],
-      specificPrincipals: ['arn:aws:iam::666666666666:role/path/to/MyRole'],
+      specificPrincipals: ['arn:aws:sts::666666666666:assumed-role/path/to/MyRole/my-session'],
       specificOrganizations: [],
       specificOrganizationalUnits: [],
       checkAnonymous: false,
@@ -2493,7 +2497,7 @@ const accountsToCheckBasedOnResourcePolicyTests: {
     }
   },
   {
-    name: 'should convert assumed-role session ARN to role ARN in PrincipalArn condition',
+    name: 'should keep unresolved assumed-role session ARN in PrincipalArn condition',
     resourcePolicy: {
       Version: '2012-10-17',
       Statement: [
@@ -2512,7 +2516,7 @@ const accountsToCheckBasedOnResourcePolicyTests: {
     },
     resourceAccountId: '000000000000',
     expected: {
-      specificPrincipals: ['arn:aws:iam::777777777777:role/SpecificRole'],
+      specificPrincipals: ['arn:aws:sts::777777777777:assumed-role/SpecificRole/session-123'],
       specificAccounts: [],
       checkAnonymous: false,
       checkAllFromResourceAccount: false,
@@ -2520,7 +2524,7 @@ const accountsToCheckBasedOnResourcePolicyTests: {
     }
   },
   {
-    name: 'should convert assumed-role session ARN with path to role ARN in PrincipalArn condition',
+    name: 'should keep unresolved path-containing assumed-role session ARN in PrincipalArn condition',
     resourcePolicy: {
       Version: '2012-10-17',
       Statement: [
@@ -2540,7 +2544,9 @@ const accountsToCheckBasedOnResourcePolicyTests: {
     },
     resourceAccountId: '000000000000',
     expected: {
-      specificPrincipals: ['arn:aws:iam::777777777777:role/path/to/SpecificRole'],
+      specificPrincipals: [
+        'arn:aws:sts::777777777777:assumed-role/path/to/SpecificRole/session-123'
+      ],
       specificAccounts: [],
       checkAnonymous: false,
       checkAllFromResourceAccount: false,
@@ -2548,7 +2554,7 @@ const accountsToCheckBasedOnResourcePolicyTests: {
     }
   },
   {
-    name: 'should convert exact assumed-role session ARN under ArnLike PrincipalArn condition',
+    name: 'should keep unresolved exact assumed-role session ARN under ArnLike PrincipalArn condition',
     resourcePolicy: {
       Version: '2012-10-17',
       Statement: [
@@ -2567,7 +2573,7 @@ const accountsToCheckBasedOnResourcePolicyTests: {
     },
     resourceAccountId: '000000000000',
     expected: {
-      specificPrincipals: ['arn:aws:iam::777777777777:role/SpecificRole'],
+      specificPrincipals: ['arn:aws:sts::777777777777:assumed-role/SpecificRole/session-123'],
       specificAccounts: [],
       checkAnonymous: false,
       checkAllFromResourceAccount: false,
@@ -2623,7 +2629,7 @@ const accountsToCheckBasedOnResourcePolicyTests: {
       allAccounts: false,
       specificAccounts: [],
       specificPrincipals: [
-        'arn:aws:iam::666666666666:role/RoleA',
+        'arn:aws:sts::666666666666:assumed-role/RoleA/session-1',
         'arn:aws:iam::777777777777:role/RoleB'
       ],
       specificOrganizations: [],
@@ -3175,6 +3181,114 @@ const accountsToCheckBasedOnResourcePolicyTests: {
 ]
 
 describe('accountsToCheckBasedOnResourcePolicy', () => {
+  it('should resolve session principals from resource policies through the collect client', async () => {
+    // Given a resource policy that names an STS session ARN without the IAM role path
+    const resourcePolicy = {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Effect: 'Allow',
+          Principal: {
+            AWS: 'arn:aws:sts::111122223333:assumed-role/ExampleRole/example-session'
+          },
+          Action: 's3:ListBucket',
+          Resource: 'arn:aws:s3:::example-bucket'
+        }
+      ]
+    }
+    const resolvedRoleArn = 'arn:aws:iam::111122223333:role/path/to/ExampleRole'
+    const client = {
+      resolvePrincipalArn: async (principalArn: string) => {
+        if (principalArn === 'arn:aws:sts::111122223333:assumed-role/ExampleRole/example-session') {
+          return resolvedRoleArn
+        }
+        return undefined
+      }
+    } as unknown as IamCollectClient
+
+    // When accountsToCheckBasedOnResourcePolicy derives the specific principals to search
+    const result = await accountsToCheckBasedOnResourcePolicy(
+      resourcePolicy,
+      '999988887777',
+      client
+    )
+
+    // Then it should use the fully resolved principal ARN so scoped whoCan calls de-duplicate it correctly
+    expect(result.specificPrincipals).toEqual([resolvedRoleArn])
+  })
+
+  it('should keep unresolved session principal ARN so it is reported as not found later', async () => {
+    // Given a resource policy that names an STS session ARN and a client that cannot resolve the role
+    const resourcePolicy = {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Effect: 'Allow',
+          Principal: {
+            AWS: 'arn:aws:sts::111122223333:assumed-role/ExampleRole/example-session'
+          },
+          Action: 's3:ListBucket',
+          Resource: 'arn:aws:s3:::example-bucket'
+        }
+      ]
+    }
+    const client = {
+      resolvePrincipalArn: async () => undefined
+    } as unknown as IamCollectClient
+
+    // When accountsToCheckBasedOnResourcePolicy derives the specific principals to search
+    const result = await accountsToCheckBasedOnResourcePolicy(
+      resourcePolicy,
+      '999988887777',
+      client
+    )
+
+    // Then it should keep the unresolved session ARN for later principalsNotFound reporting
+    expect(result.specificPrincipals).toEqual([
+      'arn:aws:sts::111122223333:assumed-role/ExampleRole/example-session'
+    ])
+  })
+
+  it('should resolve session principals extracted from PrincipalArn conditions through the collect client', async () => {
+    // Given a wildcard-principal resource policy narrowed by an exact PrincipalArn session condition
+    const resourcePolicy = {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Effect: 'Allow',
+          Principal: '*',
+          Action: 's3:ListBucket',
+          Resource: 'arn:aws:s3:::example-bucket',
+          Condition: {
+            StringEquals: {
+              'aws:PrincipalArn':
+                'arn:aws:sts::111122223333:assumed-role/ExampleRole/example-session'
+            }
+          }
+        }
+      ]
+    }
+    const resolvedRoleArn = 'arn:aws:iam::111122223333:role/path/to/ExampleRole'
+    const client = {
+      resolvePrincipalArn: async (principalArn: string) => {
+        if (principalArn === 'arn:aws:sts::111122223333:assumed-role/ExampleRole/example-session') {
+          return resolvedRoleArn
+        }
+        return undefined
+      }
+    } as unknown as IamCollectClient
+
+    // When accountsToCheckBasedOnResourcePolicy extracts the condition principal scope
+    const result = await accountsToCheckBasedOnResourcePolicy(
+      resourcePolicy,
+      '999988887777',
+      client
+    )
+
+    // Then it should use the fully resolved principal ARN from the collect client
+    expect(result.specificPrincipals).toEqual([resolvedRoleArn])
+  })
+
   for (const test of accountsToCheckBasedOnResourcePolicyTests) {
     const func = test.only ? it.only : it
     func(test.name, async () => {
@@ -3182,7 +3296,11 @@ describe('accountsToCheckBasedOnResourcePolicy', () => {
       const { resourcePolicy, resourceAccountId } = test
 
       // When accountsToCheckBasedOnResourcePolicy is called
-      const result = await accountsToCheckBasedOnResourcePolicy(resourcePolicy, resourceAccountId)
+      const result = await accountsToCheckBasedOnResourcePolicy(
+        resourcePolicy,
+        resourceAccountId,
+        noPrincipalResolutionClient
+      )
 
       // Then it should return the expected accounts
       const expected = test.expected

--- a/src/whoCan/whoCan.ts
+++ b/src/whoCan/whoCan.ts
@@ -12,11 +12,7 @@ import {
 } from '@cloud-copilot/iam-data'
 import { type Condition, type ConditionOperation, loadPolicy } from '@cloud-copilot/iam-policy'
 import { type RequestDenial, type RequestGrant } from '@cloud-copilot/iam-simulate'
-import {
-  convertAssumedRoleArnToRoleArn,
-  isAssumedRoleArn,
-  splitArnParts
-} from '@cloud-copilot/iam-utils'
+import { splitArnParts } from '@cloud-copilot/iam-utils'
 import { Arn } from '../utils/arn.js'
 import { type S3AbacOverride } from '../utils/s3Abac.js'
 import { AssumeRoleActions } from '../utils/sts.js'
@@ -573,9 +569,21 @@ function checkForServicePrincipalConditions(conditions: Condition[]): ServicePri
   return { type: 'not-service-only' }
 }
 
+/**
+ * Derives the accounts and specific principals that should be considered from a resource policy.
+ *
+ * Specific STS session principals are resolved through collect data so account-enumeration
+ * paths can de-duplicate path-qualified roles that resolve from pathless session ARNs.
+ *
+ * @param resourcePolicy The resource policy document to inspect.
+ * @param resourceAccount The account ID that owns the resource, when known.
+ * @param collectClient The collect client used to resolve canonical principal ARNs.
+ * @returns The accounts, principals, organizations, and related flags to consider for whoCan.
+ */
 export async function accountsToCheckBasedOnResourcePolicy(
   resourcePolicy: any,
-  resourceAccount: string | undefined
+  resourceAccount: string | undefined,
+  collectClient: IamCollectClient
 ): Promise<AccountsToCheck> {
   const accountsToCheck: AccountsToCheck = {
     allAccounts: false,
@@ -610,7 +618,9 @@ export async function accountsToCheckBasedOnResourcePolicy(
             accountsToCheck.resourceAccountTrustedByPolicy = true
           }
         } else {
-          accountsToCheck.specificPrincipals.push(convertSessionArnToRoleArn(principal.value()))
+          accountsToCheck.specificPrincipals.push(
+            await resolveResourcePolicyPrincipalArn(principal.value(), collectClient)
+          )
         }
       }
 
@@ -689,7 +699,9 @@ export async function accountsToCheckBasedOnResourcePolicy(
               let extractedPrincipalArnScope = false
               if (!hasWildcardOrDynamic(value)) {
                 // Exact literal — push as a specific principal
-                specificPrincipals.push(convertSessionArnToRoleArn(value))
+                specificPrincipals.push(
+                  await resolveResourcePolicyPrincipalArn(value, collectClient)
+                )
                 extractedPrincipalArnScope = true
               } else if (isExactOperator && !value.includes('*') && !value.includes('?')) {
                 // Exact operator with a dynamic variable but no wildcards — try account extraction
@@ -765,17 +777,26 @@ export async function accountsToCheckBasedOnResourcePolicy(
 }
 
 /**
- * If the princpal arn is a session, converts it to the ARN of the assumed role.
- * Otherwise returns the principal ARN as is.
+ * Resolves a resource-policy principal to the canonical collected principal ARN.
  *
- * @param principalArn The principal ARN to convert.
- * @returns The ARN of the assumed role if the principal ARN is a session, otherwise the original principal ARN.
+ * Resource policies can name STS assumed-role sessions, including pathless session
+ * ARNs for path-qualified IAM roles. Resolve through collect data first so
+ * whoCan can de-duplicate those principals before simulation, then preserve the
+ * previous session-to-role conversion behavior when the principal is not found.
+ *
+ * @param principalArn The resource-policy principal ARN or service principal to resolve.
+ * @param collectClient The collect client used to resolve canonical principal ARNs.
+ * @returns The canonical collected ARN when found, otherwise the original principal ARN.
  */
-function convertSessionArnToRoleArn(principalArn: string): string {
-  if (!isAssumedRoleArn(principalArn)) {
+async function resolveResourcePolicyPrincipalArn(
+  principalArn: string,
+  collectClient: IamCollectClient
+): Promise<string> {
+  if (!principalArn.startsWith('arn:')) {
     return principalArn
   }
-  return convertAssumedRoleArnToRoleArn(principalArn)
+
+  return (await collectClient.resolvePrincipalArn(principalArn)) ?? principalArn
 }
 
 export async function actionsForWhoCan(

--- a/src/whoCan/whoCanIntegration.test.ts
+++ b/src/whoCan/whoCanIntegration.test.ts
@@ -411,6 +411,42 @@ const whoCanIntegrationTests: WhoCanIntegrationTest[] = [
     }
   },
   {
+    name: 'resource policy account and pathless session grants do not duplicate path-qualified role results',
+    description:
+      'Resource policy grants an account and also names a pathless STS assumed-role session for a path-qualified role in that account. The same resolved role should only be returned once.',
+    data: '1',
+    request: {
+      resource: 'arn:aws:s3:::who-can-account-and-session',
+      actions: ['s3:ListBucket']
+    },
+    expected: {
+      who: [
+        {
+          action: 'ListBucket',
+          principal:
+            'arn:aws:iam::100000000001:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_AdministratorAccess_0fed56ec5d997fc5',
+          service: 's3',
+          level: 'list',
+          resourceType: 'bucket'
+        },
+        {
+          action: 'ListBucket',
+          principal: 'arn:aws:iam::200000000002:role/S3CrossAccountRole',
+          service: 's3',
+          level: 'list',
+          resourceType: 'bucket'
+        },
+        {
+          action: 'ListBucket',
+          principal: 'arn:aws:iam::200000000002:user/user1',
+          service: 's3',
+          level: 'list',
+          resourceType: 'bucket'
+        }
+      ]
+    }
+  },
+  {
     name: 'S3 object wildcard (prefix)',
     simulationCounts: { withoutIndex: 3, withIndex: 3 },
     data: '1',


### PR DESCRIPTION
## Summary
- resolve resource-policy session principals through collect data before adding them to whoCan specific principals
- keep unresolved session principals unchanged so they flow to principalsNotFound later
- add an integration fixture covering account + session grants for the same role without duplicate results
- update iam-simulate to 0.1.151 and correct an invalid assumed-role session ARN fixture

## Tests
- npx vitest --run src/whoCan/whoCan.test.ts
- npx vitest --run src/whoCan/whoCanIntegration.test.ts
- npm run build
- npm run format-check
- npm test