### PR TITLE
fix: preserve explicit resources when implicit resources are provided

### DIFF
--- a/src/principalCan/permissionSet.test.ts
+++ b/src/principalCan/permissionSet.test.ts
@@ -1014,6 +1014,72 @@ describe('addStatementToPermissionSet with implicitResources', () => {
       }
     ])
   })
+
+  it('should preserve explicit Resource when implicit resources are provided', async () => {
+    //Given a resource policy statement with an explicit Resource
+    const implicitRoleArn = 'arn:aws:iam::111122223333:role/ExampleRole'
+    const explicitBucketArn = 'arn:aws:s3:::example-bucket/*'
+    const principalArn = 'arn:aws:iam::444455556666:role/DeploymentRole'
+    const statement = loadPolicy({
+      Version: '2012-10-17',
+      Statement: {
+        Effect: 'Allow',
+        Principal: { AWS: principalArn },
+        Action: 's3:GetObject',
+        Resource: explicitBucketArn
+      }
+    }).statements()[0]
+    const permissionSet = new PermissionSet('Allow')
+
+    //When the statement is added with implicit resources
+    await addStatementToPermissionSet(statement, permissionSet, {
+      includePrincipals: true,
+      implicitResources: [implicitRoleArn]
+    })
+
+    //Then the explicit Resource should take precedence over the implicit resources
+    expectPermissionSetToMatch(permissionSet, [
+      {
+        effect: 'Allow',
+        action: 's3:GetObject',
+        resource: [explicitBucketArn],
+        principal: { AWS: [principalArn] }
+      }
+    ])
+  })
+
+  it('should preserve explicit NotResource when implicit resources are provided', async () => {
+    //Given a resource policy statement with an explicit NotResource
+    const implicitRoleArn = 'arn:aws:iam::111122223333:role/ExampleRole'
+    const explicitExcludedBucketArn = 'arn:aws:s3:::sensitive-bucket/*'
+    const principalArn = 'arn:aws:iam::444455556666:role/DeploymentRole'
+    const statement = loadPolicy({
+      Version: '2012-10-17',
+      Statement: {
+        Effect: 'Deny',
+        Principal: { AWS: principalArn },
+        Action: 's3:GetObject',
+        NotResource: explicitExcludedBucketArn
+      }
+    }).statements()[0]
+    const permissionSet = new PermissionSet('Deny')
+
+    //When the statement is added with implicit resources
+    await addStatementToPermissionSet(statement, permissionSet, {
+      includePrincipals: true,
+      implicitResources: [implicitRoleArn]
+    })
+
+    //Then the explicit NotResource should take precedence over the implicit resources
+    expectPermissionSetToMatch(permissionSet, [
+      {
+        effect: 'Deny',
+        action: 's3:GetObject',
+        notResource: [explicitExcludedBucketArn],
+        principal: { AWS: [principalArn] }
+      }
+    ])
+  })
 })
 
 describe('toPolicyStatements', () => {

--- a/src/principalCan/permissionSet.ts
+++ b/src/principalCan/permissionSet.ts
@@ -312,9 +312,9 @@ export interface AddStatementToPermissionSetOptions {
   includePrincipals?: boolean
 
   /**
-   * For resource policies that do not require a resource element
-   * such as IAM Role trust policies. Use this to provide the
-   * resource ARN(s) for these policies.
+   * Resource ARN(s) to use for resource-policy statements that do not contain Resource or
+   * NotResource, such as IAM role trust policies. Explicit Resource and NotResource values
+   * always take precedence.
    */
   implicitResources?: string[]
 }
@@ -354,6 +354,7 @@ export async function addPoliciesToPermissionSet(
  *
  * @param statement the IAM policy statement to add
  * @param permissionSet the PermissionSet to add the statement to
+ * @param options conversion options controlling principal and implicit resource handling
  * @returns nothing; the PermissionSet is modified in place
  */
 export async function addStatementToPermissionSet(
@@ -378,12 +379,12 @@ export async function addStatementToPermissionSet(
 
     let resource: string[] | undefined = undefined
     let notResource: string[] | undefined = undefined
-    if (!!options.implicitResources && options.implicitResources.length > 0) {
-      resource = options.implicitResources
-    } else if (statement.isResourceStatement()) {
+    if (statement.isResourceStatement()) {
       resource = statement.resources().map((r) => r.value())
     } else if (statement.isNotResourceStatement()) {
       notResource = statement.notResources().map((r) => r.value())
+    } else if (!!options.implicitResources?.length) {
+      resource = options.implicitResources
     }
 
     const { principal, notPrincipal } = principalFieldsFromStatement(statement, options)


### PR DESCRIPTION
## Summary
- make implicitResources a fallback only when statements do not include Resource or NotResource
- preserve explicit Resource and NotResource values when implicitResources are passed broadly
- update option documentation and add regression coverage

## Tests
- npx vitest --run src/principalCan/permissionSet.test.ts
- npm run format-check
- npm run build
- npm test

Note: Claude review skipped per maintainer request for this small change.