### PR TITLE
fix: handle source arn for service principal discovery

### DIFF
--- a/src/principalCan/principalCanIntegration.test.ts
+++ b/src/principalCan/principalCanIntegration.test.ts
@@ -181,6 +181,16 @@ const principalCanIntegrationTests: {
         },
         {
           Effect: 'Deny',
+          Action: 's3:PutObject',
+          Condition: {
+            arnnotequals: {
+              'aws:sourcearn': ['arn:aws:cloudtrail:*:*:trail/*']
+            }
+          },
+          Resource: ['arn:aws:s3:::source-arn-deny-bucket/*']
+        },
+        {
+          Effect: 'Deny',
           Action: ['s3:DeleteObject', 's3:GetObject', 's3:ListBucket', 's3:PutObject'],
           Condition: {
             stringnotequals: {

--- a/src/simulate/contextKeys.test.ts
+++ b/src/simulate/contextKeys.test.ts
@@ -1272,6 +1272,71 @@ describe('createContextKeys', () => {
     })
   })
 
+  describe('aws:SourceArn', () => {
+    it('should set aws:SourceArn for service principals in Discovery mode', async () => {
+      //Given a Discovery simulation request with a service principal
+      const simulationRequest: SimulationRequest = {
+        ...defaultSimulationRequest,
+        simulationMode: 'Discovery',
+        principal: 'cloudtrail.amazonaws.com',
+        resourceAccount: '123456789012'
+      }
+
+      //When creating context keys
+      const { contextKeys } = await createContextKeys(
+        testStore().client,
+        simulationRequest,
+        's3',
+        {}
+      )
+
+      //Then aws:SourceArn should be present so Discovery can treat its value as unknown
+      expect(contextKeys['aws:SourceArn']).toMatch(/^arn:aws:/)
+    })
+
+    it('should not set aws:SourceArn for IAM users or roles in Discovery mode', async () => {
+      //Given a Discovery simulation request with an IAM user principal
+      const simulationRequest: SimulationRequest = {
+        ...defaultSimulationRequest,
+        simulationMode: 'Discovery',
+        principal: 'arn:aws:iam::123456789012:user/test-user',
+        resourceAccount: '123456789012'
+      }
+
+      //When creating context keys
+      const { contextKeys } = await createContextKeys(
+        testStore().client,
+        simulationRequest,
+        's3',
+        {}
+      )
+
+      //Then aws:SourceArn should not be set
+      expect(contextKeys['aws:SourceArn']).toBeUndefined()
+    })
+
+    it('should not set aws:SourceArn for service principals in Strict mode', async () => {
+      //Given a Strict simulation request with a service principal
+      const simulationRequest: SimulationRequest = {
+        ...defaultSimulationRequest,
+        simulationMode: 'Strict',
+        principal: 'cloudtrail.amazonaws.com',
+        resourceAccount: '123456789012'
+      }
+
+      //When creating context keys
+      const { contextKeys } = await createContextKeys(
+        testStore().client,
+        simulationRequest,
+        's3',
+        {}
+      )
+
+      //Then aws:SourceArn should not be set without an explicit context override
+      expect(contextKeys['aws:SourceArn']).toBeUndefined()
+    })
+  })
+
   describe('aws:SourceOwner', () => {
     it('should set aws:SourceOwner to the owner of the resource account for service principals', async () => {
       // Given a simulation request with a service principal and a resource account

--- a/src/simulate/contextKeys.ts
+++ b/src/simulate/contextKeys.ts
@@ -40,6 +40,7 @@ export const knownContextKeys: readonly string[] = [
   'aws:SourceOrgID',
   'aws:SourceOrgPaths',
   'aws:SourceOwner',
+  'aws:SourceArn',
 
   'kms:CallerAccount'
 ]
@@ -202,6 +203,12 @@ export async function createContextKeys(
     contextKeys['aws:SourceOwner'] = simulationRequest.resourceAccount!
     contextKeys['aws:SourceOrgID'] = contextKeys['aws:ResourceOrgID']
     contextKeys['aws:SourceOrgPaths'] = contextKeys['aws:ResourceOrgPaths']
+
+    if (simulationRequest.simulationMode === 'Discovery') {
+      // Source key Discovery constraints make the concrete value non-authoritative;
+      // this placeholder only marks the key as present for service-originated requests.
+      contextKeys['aws:SourceArn'] = 'arn:aws:iam::000000000000:role/unknown-source'
+    }
   }
 
   //Apply any custom context key overrides

--- a/src/simulate/simulateIntegration.test.ts
+++ b/src/simulate/simulateIntegration.test.ts
@@ -358,6 +358,36 @@ const simulateIntegrationTest: {
     expected: 'ImplicitlyDenied'
   },
   {
+    name: 'resource policy Deny with aws:SourceArn treats presence as known and value as unknown',
+    comment:
+      'The role has an identity Allow for s3:PutObject, but the bucket policy has a Deny gated by ArnNotEquals aws:SourceArn. SourceArn is absent for an IAM principal request, so the negated condition matches and the explicit Deny applies.',
+    data: '1',
+    request: {
+      resourceArn: 'arn:aws:s3:::source-arn-deny-bucket/object.txt',
+      resourceAccount: undefined,
+      action: 's3:PutObject',
+      principal: 'arn:aws:iam::200000000002:role/S3CrossAccountRole',
+      customContextKeys: {},
+      simulationMode: 'Discovery'
+    },
+    expected: 'ExplicitlyDenied'
+  },
+  {
+    name: 'service principal can write when aws:SourceArn is present with an unknown value',
+    comment:
+      'The bucket policy allows CloudTrail to write for a matching SourceArn and denies writes for a nonmatching SourceArn. In Discovery mode a service request has a present SourceArn whose exact value is unknown, so the possible Allow matches while the negated Deny cannot definitively apply. No custom context is required.',
+    data: '1',
+    request: {
+      resourceArn: 'arn:aws:s3:::source-arn-deny-bucket/object.txt',
+      resourceAccount: undefined,
+      action: 's3:PutObject',
+      principal: 'cloudtrail.amazonaws.com',
+      customContextKeys: {},
+      simulationMode: 'Discovery'
+    },
+    expected: 'Allowed'
+  },
+  {
     name: 'resource policy Allow without Principal does not allow cross-account access',
     comment:
       'The Allow statement on no-principal-bucket has no Principal element. Cross-account access requires both identity and resource policy allows; with the Allow silent, the request is ImplicitlyDenied.',

--- a/src/test-datasets/iam-data-1/aws/aws/accounts/200000000002/s3/source-arn-deny-bucket/metadata.json
+++ b/src/test-datasets/iam-data-1/aws/aws/accounts/200000000002/s3/source-arn-deny-bucket/metadata.json
@@ -1,0 +1,5 @@
+{
+  "name": "source-arn-deny-bucket",
+  "region": "us-west-2",
+  "arn": "arn:aws:s3:::source-arn-deny-bucket"
+}

--- a/src/test-datasets/iam-data-1/aws/aws/accounts/200000000002/s3/source-arn-deny-bucket/policy.json
+++ b/src/test-datasets/iam-data-1/aws/aws/accounts/200000000002/s3/source-arn-deny-bucket/policy.json
@@ -1,0 +1,31 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowCloudTrailWithMatchingSourceArn",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "cloudtrail.amazonaws.com"
+      },
+      "Action": ["s3:PutObject"],
+      "Resource": ["arn:aws:s3:::source-arn-deny-bucket/*"],
+      "Condition": {
+        "ArnEquals": {
+          "aws:SourceArn": "arn:aws:cloudtrail:*:*:trail/*"
+        }
+      }
+    },
+    {
+      "Sid": "OnlyMatchingSourceArnMayWrite",
+      "Effect": "Deny",
+      "Principal": "*",
+      "Action": ["s3:PutObject"],
+      "Resource": ["arn:aws:s3:::source-arn-deny-bucket/*"],
+      "Condition": {
+        "ArnNotEquals": {
+          "aws:SourceArn": "arn:aws:cloudtrail:*:*:trail/*"
+        }
+      }
+    }
+  ]
+}

--- a/src/test-datasets/iam-data-1/aws/aws/indexes/buckets-to-accounts.json
+++ b/src/test-datasets/iam-data-1/aws/aws/indexes/buckets-to-accounts.json
@@ -70,5 +70,9 @@
   "wildcard-bucket": {
     "accountId": "100000000001",
     "region": "us-west-2"
+  },
+  "source-arn-deny-bucket": {
+    "accountId": "200000000002",
+    "region": "us-west-2"
   }
 }


### PR DESCRIPTION
## Summary
- mark aws:SourceArn as a known strict Discovery context key
- populate a non-authoritative SourceArn placeholder for service-principal Discovery requests
- add regression coverage for IAM-principal Deny and service-principal Allow behavior without custom SourceArn context

## Tests
- npx vitest --run src/simulate/contextKeys.test.ts -t 'SourceArn'
- npx vitest --run src/simulate/simulateIntegration.test.ts -t 'SourceArn'
- npm test
- npm run build
- npm run format-check

## Notes
- The new fixture is synthetic and sanitized.
- Strict mode and IAM-principal requests continue to leave aws:SourceArn absent unless explicitly provided.