### PR TITLE
fix: resolve assumed-role principal tags in simulate

### DIFF
--- a/src/simulate/contextKeys.ts
+++ b/src/simulate/contextKeys.ts
@@ -88,13 +88,15 @@ export function contextValue(context: ContextKeys, key: string): string | string
  * @param simulationRequest the simulation request to create context keys for
  * @param service the service the request is for
  * @param contextKeyOverrides the context key overrides to apply
+ * @param resolvedPrincipalArnForContext canonical principal ARN to use for role-backed context keys
  * @returns a promise that resolves to the context keys for the simulation request
  */
 export async function createContextKeys(
   collectClient: IamCollectClient,
   simulationRequest: SimulationRequest,
   service: string,
-  contextKeyOverrides: ContextKeys
+  contextKeyOverrides: ContextKeys,
+  resolvedPrincipalArnForContext?: string
 ): Promise<{ resourceTagsAreKnown: boolean; contextKeys: ContextKeys }> {
   const contextKeys: ContextKeys = {
     'aws:SecureTransport': 'true',
@@ -105,9 +107,10 @@ export async function createContextKeys(
   if (isArnPrincipal(simulationRequest.principal)) {
     const arnParts = splitArnParts(simulationRequest.principal)
     const principalArnForContext =
-      arnParts.resourceType === 'assumed-role'
+      resolvedPrincipalArnForContext ??
+      (arnParts.resourceType === 'assumed-role'
         ? convertAssumedRoleArnToRoleArn(simulationRequest.principal)
-        : simulationRequest.principal
+        : simulationRequest.principal)
     contextKeys['aws:PrincipalArn'] = principalArnForContext
     const principalAccountId = arnParts.accountId!
     contextKeys['aws:PrincipalAccount'] = arnParts.accountId || ''
@@ -121,7 +124,7 @@ export async function createContextKeys(
     }
 
     const { tags } = await collectClient.getTagsForResource(
-      simulationRequest.principal,
+      principalArnForContext,
       principalAccountId
     )
 

--- a/src/simulate/simulate.test.ts
+++ b/src/simulate/simulate.test.ts
@@ -57,6 +57,114 @@ describe('simulateRequest', () => {
     )
   })
 
+  it('should use underlying role tags for assumed-role session principals', async () => {
+    //Given an assumed-role session whose role has a tag-gated identity policy
+    const { store, client } = testStore()
+    const roleArn = 'arn:aws:iam::123456789012:role/TestRole'
+    const sessionArn = 'arn:aws:sts::123456789012:assumed-role/TestRole/TestSession'
+    await saveRole(store, {
+      arn: roleArn,
+      inlinePolicies: [
+        {
+          PolicyName: 'AllowTaggedRoleAccess',
+          PolicyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+              {
+                Effect: 'Allow',
+                Action: 's3:GetObject',
+                Resource: 'arn:aws:s3:::example-bucket/*',
+                Condition: {
+                  StringEquals: {
+                    'aws:PrincipalTag/Department': 'Engineering'
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    })
+    await store.saveResourceMetadata('123456789012', roleArn, 'tags', {
+      Department: 'Engineering'
+    })
+
+    //When simulating as the assumed-role session
+    const { request, result } = await simulateRequest(
+      {
+        simulationMode: 'Strict',
+        principal: sessionArn,
+        resourceArn: 'arn:aws:s3:::example-bucket/private.txt',
+        resourceAccount: '123456789012',
+        action: 's3:GetObject',
+        customContextKeys: {}
+      },
+      client
+    )
+
+    //Then the simulation should preserve the session principal but use role-backed context
+    expect(request.principal).toBe(sessionArn)
+    expect(request.contextVariables['aws:PrincipalArn']).toBe(roleArn)
+    if (result.resultType === 'error') {
+      assert.fail(`Simulation resulted in error: ${result.errors.message}`)
+    }
+    expect(result.overallResult).toBe('Allowed')
+  })
+
+  it('should use canonical path-qualified role tags for pathless assumed-role session principals', async () => {
+    //Given a pathless assumed-role session whose collected IAM role has a path
+    const { store, client } = testStore()
+    const roleArn = 'arn:aws:iam::123456789012:role/aws-reserved/sso.amazonaws.com/TestRole'
+    const sessionArn = 'arn:aws:sts::123456789012:assumed-role/TestRole/TestSession'
+    await saveRole(store, {
+      arn: roleArn,
+      inlinePolicies: [
+        {
+          PolicyName: 'AllowTaggedPathRoleAccess',
+          PolicyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+              {
+                Effect: 'Allow',
+                Action: 's3:GetObject',
+                Resource: 'arn:aws:s3:::example-bucket/*',
+                Condition: {
+                  StringEquals: {
+                    'aws:PrincipalTag/Department': 'Engineering'
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    })
+    await store.saveResourceMetadata('123456789012', roleArn, 'tags', {
+      Department: 'Engineering'
+    })
+
+    //When simulating as the assumed-role session
+    const { request, result } = await simulateRequest(
+      {
+        simulationMode: 'Strict',
+        principal: sessionArn,
+        resourceArn: 'arn:aws:s3:::example-bucket/private.txt',
+        resourceAccount: '123456789012',
+        action: 's3:GetObject',
+        customContextKeys: {}
+      },
+      client
+    )
+
+    //Then context keys should use the canonical collected role ARN and its tags
+    expect(request.principal).toBe(sessionArn)
+    expect(request.contextVariables['aws:PrincipalArn']).toBe(roleArn)
+    if (result.resultType === 'error') {
+      assert.fail(`Simulation resulted in error: ${result.errors.message}`)
+    }
+    expect(result.overallResult).toBe('Allowed')
+  })
+
   it('should return structured validation errors for invalid trust policies', async () => {
     const { store, client } = testStore()
     const principalArn = 'arn:aws:iam::123456789012:user/test-user'

--- a/src/simulate/simulate.ts
+++ b/src/simulate/simulate.ts
@@ -8,7 +8,13 @@ import {
   type Simulation,
   type SimulationMode
 } from '@cloud-copilot/iam-simulate'
-import { isIamRoleArn, isS3BucketOrObjectArn, splitArnParts } from '@cloud-copilot/iam-utils'
+import {
+  convertAssumedRoleArnToRoleArn,
+  isAssumedRoleArn,
+  isIamRoleArn,
+  isS3BucketOrObjectArn,
+  splitArnParts
+} from '@cloud-copilot/iam-utils'
 import { IamCollectClient, type SimulationOrgPolicies } from '../collect/client.js'
 import {
   getAllPoliciesForPrincipal,
@@ -180,11 +186,17 @@ export async function simulateRequest(
     )
   }
 
+  const principalArnForContext = await resolvePrincipalArnForContext(
+    collectClient,
+    simulationRequest.principal
+  )
+
   const { contextKeys, resourceTagsAreKnown } = await createContextKeys(
     collectClient,
     simulationRequest,
     service,
-    simulationRequest.customContextKeys
+    simulationRequest.customContextKeys,
+    principalArnForContext
   )
 
   const vpcEndpointId = contextValue(contextKeys, CONTEXT_KEYS.vpcEndpointId)
@@ -376,6 +388,33 @@ function rcpsForRequest(
       })
     }
   })
+}
+
+/**
+ * Resolves the principal ARN to use for role-backed context keys.
+ *
+ * Direct simulations can use STS assumed-role session ARNs, but collected tags
+ * and the canonical `aws:PrincipalArn` value belong to the underlying IAM role.
+ * This function performs the collected-data lookup only after the principal ARN
+ * passes the cheap assumed-role ARN check, avoiding unnecessary storage lookups
+ * for users, role ARNs, root principals, and service principals.
+ *
+ * @param collectClient the IAM collect client to use for resolving role ARNs
+ * @param principalArn the simulation principal ARN or service principal
+ * @returns the canonical role ARN for assumed-role sessions, otherwise undefined
+ */
+async function resolvePrincipalArnForContext(
+  collectClient: IamCollectClient,
+  principalArn: string
+): Promise<string | undefined> {
+  if (!isAssumedRoleArn(principalArn)) {
+    return undefined
+  }
+
+  return (
+    (await collectClient.resolvePrincipalArn(principalArn)) ??
+    convertAssumedRoleArnToRoleArn(principalArn)
+  )
 }
 
 function prepareIdentityPolicies(


### PR DESCRIPTION
## Summary
- resolve assumed-role session principals to their canonical role ARN before building simulate context keys
- use the canonical role ARN for aws:PrincipalArn and aws:PrincipalTag lookups while preserving the raw session ARN on the simulation request
- cover direct simulate calls for standard and path-qualified role sessions

## Test plan
- npx vitest --run src/simulate/simulate.test.ts -t "underlying role tags|path-qualified role tags"
- npx vitest --run src/simulate/simulate.test.ts src/simulate/contextKeys.test.ts
- npm test
- npm run format-check
- npm run build