### PR TITLE
feat: expose allowed conditions in whoCan results

### DIFF
--- a/docs/WhoCan.md
+++ b/docs/WhoCan.md
@@ -8,9 +8,17 @@ Lists all principals in your IAM data who are allowed to perform one or more spe
 
 This works by starting with the resource policy (if any) and looking for all principals, accounts, and organizations that have access to the resource. It will then check each principal for the specified actions and return a list of all principals that are allowed to perform the action.
 
+## Conditional Access Output
+
+Allowed results may include a `conditions` field when access depends on request-context values. This field is a structured expression from `iam-simulate` that describes the conditions under which the principal is allowed. Unconditional allows omit `conditions`.
+
+Allowed results may also include `ignoredConditions`, which contains the discovery-mode condition diagnostics that older `iam-lens` versions returned in `conditions`.
+
+**Breaking change:** if you were reading `conditions` as grouped ignored condition keys, migrate that usage to `ignoredConditions`.
+
 ## Wildcard Resource ARNs
 
-You can pass a wildcard resource ARN (for example, an S3 object prefix like `arn:aws:s3:::my-bucket/reports/*`). When the resource contains wildcards, results include `allowedPatterns` instead of `conditions`. Each `allowedPatterns` entry tells you which specific resource patterns allowed access for that principal/action.
+You can pass a wildcard resource ARN (for example, an S3 object prefix like `arn:aws:s3:::my-bucket/reports/*`). When the resource contains wildcards, results include `allowedPatterns` instead of top-level resource details. Each `allowedPatterns` entry tells you which specific resource patterns allowed access for that principal/action and may include its own `conditions` and `ignoredConditions` fields.
 
 Example output snippet:
 

--- a/docs/plans/whocan-conditions.md
+++ b/docs/plans/whocan-conditions.md
@@ -1,0 +1,100 @@
+# whoCan Conditions Output Plan
+
+## Feature Brief
+
+- Problem statement: `iam-simulate` now returns a structured `analysis.conditions` expression describing the conditions under which a Discovery-mode allowed request is allowed, but `iam-lens` `whoCan` still places the older `analysis.ignoredConditions` diagnostic object in the public `conditions` field.
+- Goals: For `WhoCanAllowed` and `WhoCanAllowedResourcePattern`, return the new `iam-simulate` allowed-condition expression in `conditions`, and preserve the prior ignored-condition diagnostic in a new `ignoredConditions` field.
+- Non-goals: Do not change simulation behavior, condition evaluation, deny details, CLI flags, or principal/resource discovery.
+- Target package/API: `@cloud-copilot/iam-lens` `whoCan` API and CLI JSON output; types in `src/whoCan/whoCan.ts`; mapping in `src/whoCan/WhoCanWorker.ts`.
+- User-facing behavior: Allowed `whoCan` results expose `conditions` as the new structured allowed-condition expression when present and meaningful. Existing ignored discovery-condition details move to `ignoredConditions`. Unconditional allows continue to omit `conditions` rather than emitting `{ conditionType: 'always' }`.
+- Inputs: Existing `whoCan` requests and `iam-simulate` `SuccessfulRunSimulationResults`.
+- Outputs: `WhoCanAllowed.conditions?: AllowedConditionExpression`; `WhoCanAllowed.ignoredConditions?: IgnoredConditions`; same for `WhoCanAllowedResourcePattern`.
+- Errors/diagnostics: No new errors. Existing ignored-condition diagnostics remain available under `ignoredConditions`.
+- Edge cases: Omit `conditions` when undefined or `{ conditionType: 'always' }`; omit `ignoredConditions` when undefined/empty; preserve `dependsOnSessionName`, `details`, `resourceType`, and wildcard `allowedPatterns`; handle both single-resource and wildcard-resource simulation result shapes.
+- Compatibility concerns: This changes the meaning/shape of the existing public `conditions` field and preserves old data under `ignoredConditions`. Downstream callers reading `conditions` as ignored conditions must migrate.
+- Documentation/examples impact: Update `docs/WhoCan.md` to describe `conditions` vs `ignoredConditions` and adjust examples if tests/docs include conditional output.
+- Open questions: None currently; the requested field names and target result types are explicit.
+
+## Repository Reconnaissance
+
+- Current branch/status: `main...origin/main`, working tree clean at intake.
+- Package: `@cloud-copilot/iam-lens`; `@cloud-copilot/iam-simulate` dependency is `^0.1.163` and its declarations include `RequestAnalysis.conditions?: AllowedConditionExpression` and `RequestAnalysis.ignoredConditions?: IgnoredConditions`.
+- Public API entry point: `src/index.ts` exports `whoCan`, `ResourceAccessRequest`, `WhoCanAllowed`, and `WhoCanResponse`. `WhoCanAllowedResourcePattern` is exported from `src/whoCan/whoCan.ts` but not re-exported from `src/index.ts`; this change should re-export it for typed access to `allowedPatterns` entries.
+- Current mapping: `src/whoCan/WhoCanWorker.ts` maps single allowed result `analysis.ignoredConditions` into `allowed.conditions`; wildcard allowed patterns map `r.analysis.ignoredConditions` into each pattern's `conditions`.
+- Current public types: `WhoCanAllowed.conditions?: any` and `WhoCanAllowedResourcePattern.conditions?: any` with comments describing conditions under which access is allowed. No `ignoredConditions` field exists.
+- Tests: `src/whoCan/whoCanIntegration.test.ts` expects old ignored-condition objects in `conditions` for conditional cases; `src/whoCan/whoCan.test.ts` sorting preservation test uses `conditions` generically.
+- Docs: `docs/WhoCan.md` documents wildcard output but not the conditional fields in detail.
+
+## Implementation Plan
+
+1. Update imports in `src/whoCan/whoCan.ts` to import `AllowedConditionExpression` and `IgnoredConditions` types from `@cloud-copilot/iam-simulate` along with `RequestDenial`/`RequestGrant`.
+2. Update `WhoCanAllowedResourcePattern`:
+   - Change `conditions?: any` to `conditions?: AllowedConditionExpression` and JSDoc to describe the new allowed-condition expression.
+   - Add `ignoredConditions?: IgnoredConditions` with JSDoc explaining this is the previous ignored discovery-condition diagnostic data.
+3. Update `WhoCanAllowed` similarly: `conditions?: AllowedConditionExpression`; add `ignoredConditions?: IgnoredConditions`; update JSDoc and compatibility note.
+4. Add small internal mapping helpers in `src/whoCan/WhoCanWorker.ts` (or equivalent pure local functions) to keep output omission rules consistent:
+   - `meaningfulAllowedConditions(conditions)` returns `undefined` for `undefined` or `{ conditionType: 'always' }`, otherwise returns the `AllowedConditionExpression` unchanged.
+   - `nonEmptyIgnoredConditions(ignoredConditions)` returns `undefined` for `undefined` or structurally empty ignored-condition containers, otherwise returns the `IgnoredConditions` unchanged. Treat the object as non-empty only when at least one policy-type bucket has an `allow` or `deny` array with one or more entries.
+5. Update `src/whoCan/WhoCanWorker.ts` mapping:
+   - For single allowed results: set `allowed.conditions` from `meaningfulAllowedConditions(analysis.conditions)`; set `allowed.ignoredConditions` from `nonEmptyIgnoredConditions(analysis.ignoredConditions)`.
+   - For wildcard allowed patterns: include `conditions` from `meaningfulAllowedConditions(r.analysis.conditions)` only when meaningful; include `ignoredConditions` from `nonEmptyIgnoredConditions(r.analysis.ignoredConditions)` only when non-empty. Do not emit either field as `undefined` in the object literal.
+   - Preserve existing session-name, grant-details, resource-type behavior.
+6. Update `src/index.ts` to re-export `WhoCanAllowedResourcePattern`. Do not add separate upstream type re-exports unless TypeScript build/tests reveal they are needed; callers can use the typed fields without importing the upstream types directly.
+7. Update `src/whoCan/whoCanIntegration.test.ts` expected conditional outputs so old condition objects move to `ignoredConditions`; add assertions for new `conditions` objects using the `AllowedConditionExpression` shape where deterministic. Cover at least one single-resource `WhoCanAllowed` and one wildcard `WhoCanAllowedResourcePattern` with non-trivial `conditions`.
+8. Update `src/whoCan/whoCan.test.ts` sorting preservation case to include both `conditions` and `ignoredConditions` so it verifies both fields survive sorting.
+9. Update `docs/WhoCan.md` with a concise explanation of `conditions` and `ignoredConditions`, including that unconditional allows omit `conditions`.
+
+## Test Strategy
+
+- Focused tests:
+  - `npx vitest --run src/whoCan/whoCan.test.ts src/whoCan/whoCanIntegration.test.ts`
+- Package checks after implementation:
+  - `npm run build`
+  - `npm test`
+  - `npm run format-check`
+- Meaningful assertions:
+  - Single-resource `WhoCanAllowed` includes `conditions` as `conditionType: 'condition'` or appropriate expression and includes old diagnostic under `ignoredConditions`.
+  - Wildcard `WhoCanAllowedResourcePattern` includes `conditions` from each allowed pattern and old diagnostic under `ignoredConditions`.
+  - Unconditional allowed results omit `conditions` rather than returning `{ conditionType: 'always' }`.
+  - Sorting preserves both fields.
+
+## Risks and Edge Cases
+
+- Existing tests may need multiple expected expression shapes if `iam-simulate` combines identity/resource/SCP/RCP conditions into groups. Use precise assertions from current deterministic fixture outputs rather than broad snapshots.
+- Public API compatibility is intentionally changed for `conditions`; preserving `ignoredConditions` mitigates data loss but not type/shape compatibility. Document this as a migration note in `docs/WhoCan.md` and use a `feat:` commit/PR title per repo workflow; package release semantics are managed by the repository's semantic-release config.
+- Avoid emitting empty ignored-condition objects or trivial `{ conditionType: 'always' }` conditions.
+
+## Alternatives Considered
+
+- Add only `ignoredConditions` and leave `conditions` unchanged: rejected because the requested user-visible behavior is to put the new `iam-simulate` object in `conditions`.
+- Add `allowedConditions` instead of reusing `conditions`: rejected because user explicitly requested the new conditions object in `conditions`.
+- Keep `any` types: rejected because `iam-simulate` now exports semantic types and this is a public API contract change.
+
+## Commands/Checks to Run
+
+```bash
+npx vitest --run src/whoCan/whoCan.test.ts src/whoCan/whoCanIntegration.test.ts
+npm run build
+npm test
+npm run format-check
+```
+
+## Rollback/Follow-up Considerations
+
+- `docs/WhoCan.md` will include the migration note for `conditions` vs `ignoredConditions` as part of this change.
+- If downstream callers later need to import `AllowedConditionExpression`/`IgnoredConditions` directly from `iam-lens`, consider a follow-up explicit type re-export. This plan only requires typed fields and `WhoCanAllowedResourcePattern` re-export.
+
+## Pre-Implementation Confidence Gate
+
+- [x] Discovery findings recorded
+- [x] Product behavior is explicit
+- [x] Inputs are final enough to implement
+- [x] Outputs are final enough to implement
+- [x] Exported types/APIs are final enough to implement
+- [x] Error/diagnostic behavior is explicit
+- [x] Test strategy is explicit
+- [x] Docs/examples impact is explicit
+- [x] Backwards compatibility impact is explicit
+- [x] Claude plan review concerns resolved
+- [x] Codex/current-model plan review concerns resolved
+- [ ] User approved implementation

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ export {
   type WhoCanPrincipalScope,
   type ResourceAccessRequest,
   type WhoCanAllowed,
+  type WhoCanAllowedResourcePattern,
   type WhoCanResponse
 } from './whoCan/whoCan.js'
 export {

--- a/src/whoCan/WhoCanWorker.ts
+++ b/src/whoCan/WhoCanWorker.ts
@@ -1,7 +1,9 @@
 import { iamActionDetails } from '@cloud-copilot/iam-data'
 import {
+  type AllowedConditionExpression,
   type EvaluationResult,
   getGrantReasons,
+  type IgnoredConditions,
   type RequestAnalysis,
   type SuccessfulRunSimulationResults
 } from '@cloud-copilot/iam-simulate'
@@ -222,6 +224,46 @@ async function getActionLevel(service: string, action: string): Promise<string> 
   return details.accessLevel
 }
 
+/**
+ * Return an allowed-condition expression only when it represents a meaningful
+ * access constraint for whoCan output.
+ *
+ * @param conditions the allowed-condition expression returned by iam-simulate
+ * @returns the expression when it is meaningful, otherwise undefined
+ */
+function meaningfulAllowedConditions(
+  conditions: AllowedConditionExpression | undefined
+): AllowedConditionExpression | undefined {
+  if (!conditions || conditions.conditionType === 'always') {
+    return undefined
+  }
+  return conditions
+}
+
+/**
+ * Return ignored discovery-condition diagnostics only when at least one policy
+ * bucket contains ignored allow or deny condition entries.
+ *
+ * @param ignoredConditions the ignored-condition diagnostics returned by iam-simulate
+ * @returns the diagnostics when non-empty, otherwise undefined
+ */
+function nonEmptyIgnoredConditions(
+  ignoredConditions: IgnoredConditions | undefined
+): IgnoredConditions | undefined {
+  if (!ignoredConditions) {
+    return undefined
+  }
+
+  for (const conditionBucket of Object.values(ignoredConditions)) {
+    // IgnoredConditions buckets are shaped as optional allow/deny arrays per policy type.
+    if ((conditionBucket.allow?.length ?? 0) > 0 || (conditionBucket.deny?.length ?? 0) > 0) {
+      return ignoredConditions
+    }
+  }
+
+  return undefined
+}
+
 function mapSimulationResultToWhoCanExecutionResult(
   workItem: WhoCanWorkItem,
   service: string,
@@ -244,8 +286,14 @@ function mapSimulationResultToWhoCanExecutionResult(
 
     if (simulationResponse.resultType === 'single') {
       const analysis = simulationResponse.result.analysis
-      if (analysis.ignoredConditions && Object.keys(analysis.ignoredConditions).length > 0) {
-        allowed.conditions = analysis.ignoredConditions
+      const conditions = meaningfulAllowedConditions(analysis.conditions)
+      if (conditions) {
+        allowed.conditions = conditions
+      }
+
+      const ignoredConditions = nonEmptyIgnoredConditions(analysis.ignoredConditions)
+      if (ignoredConditions) {
+        allowed.ignoredConditions = ignoredConditions
       }
 
       if (analysis.ignoredRoleSessionName) {
@@ -263,10 +311,13 @@ function mapSimulationResultToWhoCanExecutionResult(
       const allowedPatterns: WhoCanAllowedResourcePattern[] = []
       for (const r of simulationResponse.results) {
         if (r.analysis.result === 'Allowed') {
+          const conditions = meaningfulAllowedConditions(r.analysis.conditions)
+          const ignoredConditions = nonEmptyIgnoredConditions(r.analysis.ignoredConditions)
           allowedPatterns.push({
             pattern: r.resourcePattern,
             resourceType: r.resourceType,
-            conditions: r.analysis.ignoredConditions,
+            ...(conditions && { conditions }),
+            ...(ignoredConditions && { ignoredConditions }),
             dependsOnSessionName: r.analysis.ignoredRoleSessionName ? true : undefined,
             ...(collectGrantDetails && { details: getGrantReasons(r.analysis) })
           })

--- a/src/whoCan/whoCan.test.ts
+++ b/src/whoCan/whoCan.test.ts
@@ -3751,7 +3751,22 @@ describe('sortWhoCanResults', () => {
           service: 's3',
           action: 'GetObject',
           level: 'object',
-          conditions: { StringEquals: { 's3:prefix': 'test/' } },
+          conditions: {
+            conditionType: 'condition',
+            op: 'StringEquals',
+            key: 's3:prefix',
+            values: ['test/'],
+            sources: [
+              {
+                policyType: 'identity',
+                effect: 'Allow',
+                statementIndex: 1
+              }
+            ]
+          },
+          ignoredConditions: {
+            identity: { allow: [{ op: 'StringEquals', key: 's3:prefix', values: ['test/'] }] }
+          },
           dependsOnSessionName: true
         },
         {
@@ -3759,7 +3774,24 @@ describe('sortWhoCanResults', () => {
           service: 's3',
           action: 'PutObject',
           level: 'object',
-          conditions: { IpAddress: { 'aws:SourceIp': '192.168.1.0/24' } }
+          conditions: {
+            conditionType: 'condition',
+            op: 'IpAddress',
+            key: 'aws:SourceIp',
+            values: ['192.168.1.0/24'],
+            sources: [
+              {
+                policyType: 'identity',
+                effect: 'Allow',
+                statementIndex: 1
+              }
+            ]
+          },
+          ignoredConditions: {
+            identity: {
+              allow: [{ op: 'IpAddress', key: 'aws:SourceIp', values: ['192.168.1.0/24'] }]
+            }
+          }
         }
       ],
       allAccountsChecked: true,
@@ -3780,14 +3812,46 @@ describe('sortWhoCanResults', () => {
         service: 's3',
         action: 'PutObject',
         level: 'object',
-        conditions: { IpAddress: { 'aws:SourceIp': '192.168.1.0/24' } }
+        conditions: {
+          conditionType: 'condition',
+          op: 'IpAddress',
+          key: 'aws:SourceIp',
+          values: ['192.168.1.0/24'],
+          sources: [
+            {
+              policyType: 'identity',
+              effect: 'Allow',
+              statementIndex: 1
+            }
+          ]
+        },
+        ignoredConditions: {
+          identity: {
+            allow: [{ op: 'IpAddress', key: 'aws:SourceIp', values: ['192.168.1.0/24'] }]
+          }
+        }
       },
       {
         principal: 'arn:aws:iam::123456789012:role/RoleB',
         service: 's3',
         action: 'GetObject',
         level: 'object',
-        conditions: { StringEquals: { 's3:prefix': 'test/' } },
+        conditions: {
+          conditionType: 'condition',
+          op: 'StringEquals',
+          key: 's3:prefix',
+          values: ['test/'],
+          sources: [
+            {
+              policyType: 'identity',
+              effect: 'Allow',
+              statementIndex: 1
+            }
+          ]
+        },
+        ignoredConditions: {
+          identity: { allow: [{ op: 'StringEquals', key: 's3:prefix', values: ['test/'] }] }
+        },
         dependsOnSessionName: true
       }
     ])

--- a/src/whoCan/whoCan.ts
+++ b/src/whoCan/whoCan.ts
@@ -11,7 +11,12 @@ import {
   type ResourceType
 } from '@cloud-copilot/iam-data'
 import { type Condition, type ConditionOperation, loadPolicy } from '@cloud-copilot/iam-policy'
-import { type RequestDenial, type RequestGrant } from '@cloud-copilot/iam-simulate'
+import {
+  type AllowedConditionExpression,
+  type IgnoredConditions,
+  type RequestDenial,
+  type RequestGrant
+} from '@cloud-copilot/iam-simulate'
 import { splitArnParts } from '@cloud-copilot/iam-utils'
 import { Arn } from '../utils/arn.js'
 import { type S3AbacOverride } from '../utils/s3Abac.js'
@@ -130,9 +135,16 @@ export interface WhoCanAllowedResourcePattern {
   resourceType: string
 
   /**
-   * The conditions under which access is allowed for this pattern, if any.
+   * The structured expression describing the conditions under which access is allowed
+   * for this pattern. Undefined when access is unconditional.
    */
-  conditions?: any
+  conditions?: AllowedConditionExpression
+
+  /**
+   * Discovery-mode condition diagnostics that were ignored while determining this
+   * pattern could be allowed. This was returned in `conditions` in earlier versions.
+   */
+  ignoredConditions?: IgnoredConditions
 
   /**
    * If true, access is only allowed when the session has a specific session name.
@@ -152,11 +164,17 @@ export interface WhoCanAllowed {
   level: string
 
   /**
-   * The conditions under which access is allowed, if any.
-   * This will be undefined if access is allowed unconditionally or
-   * if `allowedPatterns` are provided.
+   * The structured expression describing the conditions under which access is allowed.
+   * This will be undefined if access is allowed unconditionally or if `allowedPatterns`
+   * are provided.
    */
-  conditions?: any
+  conditions?: AllowedConditionExpression
+
+  /**
+   * Discovery-mode condition diagnostics that were ignored while determining access
+   * could be allowed. This was returned in `conditions` in earlier versions.
+   */
+  ignoredConditions?: IgnoredConditions
 
   /**
    * The resource type for the allowed action. This will be undefined if `allowedPatterns` are provided,

--- a/src/whoCan/whoCanIntegration.test.ts
+++ b/src/whoCan/whoCanIntegration.test.ts
@@ -10,6 +10,104 @@ import {
 } from './whoCan.js'
 import { WhoCanProcessor } from './WhoCanProcessor.js'
 
+/**
+ * Build the expected iam-simulate source metadata for a resource-policy allow statement.
+ *
+ * @param statementId the expected statement ID
+ * @returns the expected resource-policy source metadata
+ */
+function resourceAllowSource(statementId: string) {
+  return {
+    effect: 'Allow',
+    policyIdentifier: undefined,
+    policyType: 'resource',
+    statementId,
+    statementIndex: 1
+  }
+}
+
+/**
+ * Build the expected iam-simulate source metadata for an identity-policy allow statement.
+ *
+ * @param policyIdentifier the expected identity policy identifier
+ * @returns the expected identity-policy source metadata
+ */
+function identityAllowSource(policyIdentifier: string) {
+  return {
+    effect: 'Allow',
+    policyIdentifier,
+    policyType: 'identity',
+    statementIndex: 1
+  }
+}
+
+/**
+ * Build the expected allowed-condition expression for a required role session name.
+ *
+ * @param sessionName the expected role session name
+ * @param statementId the resource-policy statement requiring the session name
+ * @returns the expected session-name condition expression
+ */
+function sessionNameCondition(sessionName: string, statementId: string) {
+  return {
+    conditionType: 'sessionName',
+    sessionName: [sessionName],
+    sources: [resourceAllowSource(statementId)]
+  }
+}
+
+/**
+ * Build the expected allowed-condition expression for a policy condition.
+ *
+ * @param op the IAM condition operator
+ * @param key the IAM condition key
+ * @param values the expected condition values
+ * @param source the expected source statement metadata
+ * @returns the expected policy-condition expression
+ */
+function conditionExpression(
+  op: string,
+  key: string,
+  values: string[],
+  source: ReturnType<typeof resourceAllowSource> | ReturnType<typeof identityAllowSource>
+) {
+  return {
+    conditionType: 'condition',
+    op,
+    key,
+    values,
+    sources: [source]
+  }
+}
+
+/**
+ * Build the expected ignored-condition diagnostics for an allow-side condition.
+ *
+ * @param policyType the policy type that contained the ignored condition
+ * @param op the IAM condition operator
+ * @param key the IAM condition key
+ * @param values the ignored condition values
+ * @returns the expected ignored-condition diagnostics
+ */
+function ignoredAllowCondition(
+  policyType: 'identity' | 'resource',
+  op: string,
+  key: string,
+  values: string[]
+) {
+  return {
+    [policyType]: {
+      allow: [
+        {
+          key,
+          op,
+          values
+        }
+      ]
+    }
+  }
+}
+
 interface WhoCanIntegrationTest {
   only?: true
   name: string
@@ -230,7 +328,8 @@ const whoCanIntegrationTests: WhoCanIntegrationTest[] = [
           principal: 'arn:aws:iam::200000000002:role/DynamoDbRole',
           service: 's3',
           resourceType: 'bucket',
-          dependsOnSessionName: true
+          dependsOnSessionName: true,
+          conditions: sessionNameCondition('my-session', 'SharingWithSessionArn')
         },
         {
           action: 'ListBucket',
@@ -267,7 +366,11 @@ const whoCanIntegrationTests: WhoCanIntegrationTest[] = [
           principal: 'arn:aws:iam::200000000002:role/DynamoDbRole',
           service: 's3',
           resourceType: 'bucket',
-          dependsOnSessionName: true
+          dependsOnSessionName: true,
+          conditions: sessionNameCondition(
+            'my-session',
+            'SharingWithSessionArnAndPrincipalArnCondition'
+          )
         },
         {
           action: 'ListBucket',
@@ -308,16 +411,21 @@ const whoCanIntegrationTests: WhoCanIntegrationTest[] = [
           resourceType: 'bucket',
           dependsOnSessionName: true,
           conditions: {
-            resource: {
-              allow: [
-                {
-                  key: 'aws:userid',
-                  op: 'StringLike',
-                  values: ['*:my-session']
-                }
-              ]
-            }
-          }
+            conditionType: 'group',
+            operator: 'and',
+            conditions: [
+              conditionExpression(
+                'StringLike',
+                'aws:userid',
+                ['*:my-session'],
+                resourceAllowSource('SessionWithUserIdCondition')
+              ),
+              sessionNameCondition('my-session', 'SessionWithUserIdCondition')
+            ]
+          },
+          ignoredConditions: ignoredAllowCondition('resource', 'StringLike', 'aws:userid', [
+            '*:my-session'
+          ])
         },
         {
           action: 'ListBucket',
@@ -367,7 +475,8 @@ const whoCanIntegrationTests: WhoCanIntegrationTest[] = [
           service: 's3',
           level: 'list',
           resourceType: 'bucket',
-          dependsOnSessionName: true
+          dependsOnSessionName: true,
+          conditions: sessionNameCondition('session-abc', 'SharingWithCrossAccountSessionArn')
         }
       ]
     }
@@ -390,7 +499,11 @@ const whoCanIntegrationTests: WhoCanIntegrationTest[] = [
           service: 's3',
           level: 'list',
           resourceType: 'bucket',
-          dependsOnSessionName: true
+          dependsOnSessionName: true,
+          conditions: sessionNameCondition(
+            'session-abc',
+            'AllowPathQualifiedRoleSessionWithoutPath'
+          )
         },
         {
           action: 'ListBucket',
@@ -757,17 +870,18 @@ const whoCanIntegrationTests: WhoCanIntegrationTest[] = [
           service: 's3',
           level: 'write',
           resourceType: 'object',
-          conditions: {
-            resource: {
-              allow: [
-                {
-                  key: 'aws:SourceAccount',
-                  op: 'StringEquals',
-                  values: ['400000000001']
-                }
-              ]
-            }
-          }
+          conditions: conditionExpression(
+            'StringEquals',
+            'aws:SourceAccount',
+            ['400000000001'],
+            resourceAllowSource('AllowLambdaFromDifferentSourceAccount')
+          ),
+          ignoredConditions: ignoredAllowCondition(
+            'resource',
+            'StringEquals',
+            'aws:SourceAccount',
+            ['400000000001']
+          )
         }
       ]
     }
@@ -788,17 +902,15 @@ const whoCanIntegrationTests: WhoCanIntegrationTest[] = [
           service: 's3',
           level: 'list',
           resourceType: 'bucket',
-          conditions: {
-            identity: {
-              allow: [
-                {
-                  key: 'aws:SourceVpc',
-                  op: 'StringEquals',
-                  values: ['vpc-123456789']
-                }
-              ]
-            }
-          }
+          conditions: conditionExpression(
+            'StringEquals',
+            'aws:SourceVpc',
+            ['vpc-123456789'],
+            identityAllowSource('arn:aws:iam::200000000002:role/VpcBucketRole#ListBucket')
+          ),
+          ignoredConditions: ignoredAllowCondition('identity', 'StringEquals', 'aws:SourceVpc', [
+            'vpc-123456789'
+          ])
         }
       ]
     }
@@ -819,17 +931,15 @@ const whoCanIntegrationTests: WhoCanIntegrationTest[] = [
           service: 's3',
           level: 'list',
           resourceType: 'bucket',
-          conditions: {
-            identity: {
-              allow: [
-                {
-                  key: 'aws:SourceVpc',
-                  op: 'StringEquals',
-                  values: ['vpc-123456789']
-                }
-              ]
-            }
-          }
+          conditions: conditionExpression(
+            'StringEquals',
+            'aws:SourceVpc',
+            ['vpc-123456789'],
+            identityAllowSource('arn:aws:iam::200000000002:role/VpcBucketRole#ListBucket')
+          ),
+          ignoredConditions: ignoredAllowCondition('identity', 'StringEquals', 'aws:SourceVpc', [
+            'vpc-123456789'
+          ])
         }
       ]
     }
@@ -1131,17 +1241,15 @@ const whoCanIntegrationTests: WhoCanIntegrationTest[] = [
           service: 's3',
           level: 'list',
           resourceType: 'bucket',
-          conditions: {
-            identity: {
-              allow: [
-                {
-                  key: 'aws:SourceVpc',
-                  op: 'StringEquals',
-                  values: ['vpc-123456789']
-                }
-              ]
-            }
-          },
+          conditions: conditionExpression(
+            'StringEquals',
+            'aws:SourceVpc',
+            ['vpc-123456789'],
+            identityAllowSource('arn:aws:iam::200000000002:role/VpcBucketRole#ListBucket')
+          ),
+          ignoredConditions: ignoredAllowCondition('identity', 'StringEquals', 'aws:SourceVpc', [
+            'vpc-123456789'
+          ]),
           details: [
             {
               policyIdentifier: 'arn:aws:iam::200000000002:role/VpcBucketRole#ListBucket',


### PR DESCRIPTION
## Summary

- Expose the new `iam-simulate` allowed-condition expression on `whoCan` allowed results as `conditions`
- Move the legacy discovery-mode ignored condition diagnostics to `ignoredConditions`
- Apply the same field behavior to wildcard-resource `allowedPatterns` entries
- Re-export `WhoCanAllowedResourcePattern` for typed access to `allowedPatterns` entries
- Document the `conditions`/`ignoredConditions` compatibility change

## Key design decisions

- Omit `conditions` for unconditional allows, including trivial `{ conditionType: 'always' }` expressions
- Omit `ignoredConditions` when the upstream ignored-condition diagnostic buckets are empty
- Preserve existing `dependsOnSessionName`, grant details, resource type, and wildcard resource behavior

## Tests

- Updated whoCan integration expectations for single-resource condition output
- Updated sorting tests to verify both `conditions` and `ignoredConditions` survive sorting

Commands run:

```bash
npx vitest --run src/whoCan/whoCan.test.ts src/whoCan/whoCanIntegration.test.ts
npm run build
npm test
npm run format-check
```

## Review status

- Claude plan review completed; concerns resolved before implementation
- Current-model plan review completed; no blockers after plan updates
- Claude implementation review completed; non-blocking docs/comment suggestions addressed
- Current-model implementation review completed; approved with non-blocking wildcard conditional coverage note

## Risks / follow-ups

- This intentionally changes the public meaning/shape of `conditions`; callers using the legacy grouped ignored-condition object should migrate to `ignoredConditions`
- A future follow-up could add explicit convenience re-exports for upstream condition types if callers ask for them
