### PR TITLE
fix: use iam-utils resource type matching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
         "@cloud-copilot/iam-expand": "^0.11.29",
         "@cloud-copilot/iam-policy": "^0.1.89",
         "@cloud-copilot/iam-shrink": "^0.1.21",
-        "@cloud-copilot/iam-simulate": "^0.1.163",
-        "@cloud-copilot/iam-utils": "^0.1.63",
+        "@cloud-copilot/iam-simulate": "^0.1.166",
+        "@cloud-copilot/iam-utils": "^0.1.78",
         "@cloud-copilot/job": "^0.1.0",
         "@cloud-copilot/log": "^0.1.39",
         "bitset": "^5.2.3"
@@ -1348,20 +1348,20 @@
       }
     },
     "node_modules/@cloud-copilot/iam-simulate": {
-      "version": "0.1.163",
-      "resolved": "https://registry.npmjs.org/@cloud-copilot/iam-simulate/-/iam-simulate-0.1.163.tgz",
-      "integrity": "sha512-a8TrK7ulyt6A3M57HzT0DQ0Es8TuAVTiWSuYzGSGzHty1JwYAJZVDlie1B1hsrKvvBr662ok2DUHujMTvA17GA==",
+      "version": "0.1.166",
+      "resolved": "https://registry.npmjs.org/@cloud-copilot/iam-simulate/-/iam-simulate-0.1.166.tgz",
+      "integrity": "sha512-FFNcxjHvYpkrjoq+ucb9d2fzo+8cLov+3m99ZH/KYOBBKiG0zoNbJMxR/rIjAUnG35VnlJMtKGlmQZXjXBkd/g==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@cloud-copilot/iam-data": ">=0.15.202511222 <1.0.0",
         "@cloud-copilot/iam-policy": "^0.1.89",
-        "@cloud-copilot/iam-utils": "^0.1.54"
+        "@cloud-copilot/iam-utils": "^0.1.78"
       }
     },
     "node_modules/@cloud-copilot/iam-utils": {
-      "version": "0.1.75",
-      "resolved": "https://registry.npmjs.org/@cloud-copilot/iam-utils/-/iam-utils-0.1.75.tgz",
-      "integrity": "sha512-oX84ujkfYgyYw2H69jzBsGpitG+bNorhWug45ZoBCOtFGV5Zc+j6ADT2g5DSJeJ/HLwCHfGZXeqcD3Pr3Dq+7w==",
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@cloud-copilot/iam-utils/-/iam-utils-0.1.78.tgz",
+      "integrity": "sha512-9heAu67B2yUxdPSwHNXQInRo6WQhTgJ9xY9HHrdrPqIg3j9SW0uqAJkmJQPqRF13XJKId/b2yxeiC31tAKBlkA==",
       "license": "AGPL-3.0-or-later"
     },
     "node_modules/@cloud-copilot/job": {

--- a/package.json
+++ b/package.json
@@ -116,8 +116,8 @@
     "@cloud-copilot/iam-expand": "^0.11.29",
     "@cloud-copilot/iam-policy": "^0.1.89",
     "@cloud-copilot/iam-shrink": "^0.1.21",
-    "@cloud-copilot/iam-simulate": "^0.1.163",
-    "@cloud-copilot/iam-utils": "^0.1.63",
+    "@cloud-copilot/iam-simulate": "^0.1.166",
+    "@cloud-copilot/iam-utils": "^0.1.78",
     "@cloud-copilot/job": "^0.1.0",
     "@cloud-copilot/log": "^0.1.39",
     "bitset": "^5.2.3"

--- a/src/whoCan/whoCan.test.ts
+++ b/src/whoCan/whoCan.test.ts
@@ -31,6 +31,13 @@ const findResourceTypeForArnTests: {
     }
   },
   {
+    input: 'arn:aws:S3:::my-bucket',
+    expected: {
+      service: 's3',
+      key: 'bucket'
+    }
+  },
+  {
     input: 'arn:aws:s3:::my-bucket/a',
     expected: {
       service: 's3',

--- a/src/whoCan/whoCan.ts
+++ b/src/whoCan/whoCan.ts
@@ -17,7 +17,7 @@ import {
   type RequestDenial,
   type RequestGrant
 } from '@cloud-copilot/iam-simulate'
-import { splitArnParts } from '@cloud-copilot/iam-utils'
+import { mostSpecificMatchingResourceTypePatterns, splitArnParts } from '@cloud-copilot/iam-utils'
 import { Arn } from '../utils/arn.js'
 import { type S3AbacOverride } from '../utils/s3Abac.js'
 import { AssumeRoleActions } from '../utils/sts.js'
@@ -891,32 +891,18 @@ export async function findResourceTypeForArn(resourceArn: string): Promise<[stri
   }
 
   const sortedResourceTypes = await allResourceTypesByArnLength(service)
-  for (const rt of sortedResourceTypes) {
-    const pattern = convertResourcePatternToRegex(rt.arn)
-    const match = resourceArn.match(new RegExp(pattern))
-    if (match) {
-      return [service, rt]
-    }
+  const matchingPatterns = mostSpecificMatchingResourceTypePatterns(
+    resourceArn,
+    sortedResourceTypes.map((resourceType) => resourceType.arn)
+  )
+  const resourceType = sortedResourceTypes.find((rt) => matchingPatterns.includes(rt.arn))
+  if (resourceType) {
+    return [service, resourceType]
   }
 
   throw new Error(
     `Unable to find resource type for service ${service} and resource ${resourceArn}.`
   )
-}
-
-/**
- * Convert a resource pattern from iam-data to a regex pattern
- *
- * @param pattern the pattern to convert to a regex
- * @returns the regex pattern
- */
-export function convertResourcePatternToRegex(pattern: string): string {
-  const regex = pattern.replace(/\$\{.*?\}/g, (match, position) => {
-    const name = match.substring(2, match.length - 1)
-    const camelName = name.at(0)?.toLowerCase() + name.substring(1)
-    return `(?<${camelName}>(.+?))`
-  })
-  return `^${regex}$`
 }
 
 async function allResourceTypesByArnLength(service: string): Promise<ResourceType[]> {


### PR DESCRIPTION
## Summary
- bump `@cloud-copilot/iam-utils` to `^0.1.78` and `@cloud-copilot/iam-simulate` to `^0.1.166`
- refactor `findResourceTypeForArn` to use `mostSpecificMatchingResourceTypePatterns` from iam-utils
- remove the local resource pattern regex fallback/helper
- add mixed-case service ARN regression coverage

## Tests
- `npx vitest --run src/whoCan/whoCan.test.ts`
- `npm test`
- `npm run format-check`
- `npm run build`
